### PR TITLE
Link Roundup Options & FE-135

### DIFF
--- a/argo-link-roundups.php
+++ b/argo-link-roundups.php
@@ -187,6 +187,7 @@ class ArgoLinkRoundups {
 		// register our settings
 		register_setting('argolinkroundups-settings-group', 'argo_link_roundups_custom_url');
 		register_setting('argolinkroundups-settings-group', 'argo_link_roundups_custom_html');
+		register_setting('argolinkroundups-settings-group', 'argo_link_roundups_sponsored_style');
 		register_setting(
 			'argolinkroundups-settings-group', 'link_roundups_custom_name_singular'
 		);

--- a/argo-link-roundups.php
+++ b/argo-link-roundups.php
@@ -65,21 +65,39 @@ class ArgoLinkRoundups {
 	 * @since 0.1
 	 */
 	public static function register_post_type() {
+	$singular_opt = get_option('link_roundups_custom_name_singular');
+	$plural_opt = get_option('link_roundups_custom_name_plural');
+	$slug_opt = get_option('argo_link_roundups_custom_url');
+	
+	if($singular_opt != "") {
+		$singular = $singular_opt;
+	}
+	else {
+		$singular = 'Link Roundup';
+	}
+	
+	if($plural_opt != "") {
+		$plural = $plural_opt;
+	}
+	else {
+		$plural = 'Link Roundups';
+	}
+	
 		$roundup_options = array(
 			'labels' => array(
-				'name' => 'Link Roundups',
-				'singular_name' => 'Link Roundup',
-				'add_new' => 'Add New Roundup',
-				'add_new_item' => 'Add New Link Roundup',
+				'name' => $plural,
+				'singular_name' => $singular,
+				'add_new' => 'Add '. $singular,
+				'add_new_item' => 'Add New '. $singular,
 				'edit' => 'Edit',
-				'edit_item' => 'Edit Link Roundup',
+				'edit_item' => 'Edit ' . $singular,
 				'view' => 'View',
-				'view_item' => 'View Link Roundup',
-				'search_items' => 'Search Link Roundups',
-				'not_found' => 'No Links Roundups found',
-				'not_found_in_trash' => 'No Link Roundups found in Trash',
+				'view_item' => 'View ' . $singular,
+				'search_items' => 'Search ' . $plural,
+				'not_found' => 'No ' . $plural . ' found',
+				'not_found_in_trash' => 'No ' . $plural . ' found in Trash',
 			),
-			'description' => 'Link Roundups',
+			'description' => $plural,
 			'supports' => array(
 				'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks', 'custom-fields',
 				'comments', 'revisions', 'page-attributes', 'post-formats'
@@ -91,8 +109,8 @@ class ArgoLinkRoundups {
 			'has_archive' => true,
 		);
 
-		if (get_option('argo_link_roundups_custom_url') != "")
-			$roundup_options['rewrite'] = array('slug' => get_option('argo_link_roundups_custom_url'));
+		if ($slug_opt != "")
+			$roundup_options['rewrite'] = array('slug' => $slug_opt);
 
 		register_post_type('roundup', $roundup_options);
 

--- a/argo-link-roundups.php
+++ b/argo-link-roundups.php
@@ -170,6 +170,12 @@ class ArgoLinkRoundups {
 		register_setting('argolinkroundups-settings-group', 'argo_link_roundups_custom_url');
 		register_setting('argolinkroundups-settings-group', 'argo_link_roundups_custom_html');
 		register_setting(
+			'argolinkroundups-settings-group', 'link_roundups_custom_name_singular'
+		);
+		register_setting(
+			'argolinkroundups-settings-group', 'link_roundups_custom_name_plural'
+		);
+		register_setting(
 			'argolinkroundups-settings-group', 'argo_link_roundups_use_mailchimp_integration',
 			array(__CLASS__, 'validate_mailchimp_integration')
 		);

--- a/argo-links-class.php
+++ b/argo-links-class.php
@@ -544,7 +544,9 @@ class ArgoLinks {
 		$style = $link_style; // $link_style is defined below in rounduplink_shortcode()
 		
 		ob_start(); 
+		
 		/* begin shortcode output
+		 *
 		 * NOTE: 
 		 * This default output is overwritten 98% of the time by $argo_html 
 		 * regardless of whether you've modified the code in setting

--- a/argo-links-class.php
+++ b/argo-links-class.php
@@ -528,29 +528,38 @@ class ArgoLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function get_html( $post = null ) {
+	public static function get_html( $post = null, $link_style = null) {
 
-		$post = get_post($post);
+		$post = get_post($post); // getting a saved link...
 
 		if(!$post)
 			return;
 
-		$meta = get_post_meta($post->ID);
+		$meta = get_post_meta($post->ID); // getting meta fields from saved link...
 
 		$url = !empty($meta["argo_link_url"]) ? $meta["argo_link_url"][0] : '';
 		$title = get_the_title($post->ID);
-		$description = array_key_exists("argo_link_description",$meta) ? $meta["argo_link_description"][0] : '';;
+		$description = array_key_exists("argo_link_description",$meta) ? $meta["argo_link_description"][0] : '';
 		$source = !empty($meta["argo_link_source"]) ? $meta["argo_link_source"][0] : '';
-
-		ob_start();
-?>
-	  <p class='link-roundup'>
+		$style = $link_style; // $link_style is defined below in rounduplink_shortcode()
+		
+		ob_start(); 
+		/* begin shortcode output
+		 * NOTE: 
+		 * This default output is overwritten 98% of the time by $argo_html 
+		 * regardless of whether you've modified the code in setting
+		 * Needs improvement in future version
+		*/
+		?>
+		
+	  <p class='link-roundups' style='#!STYLE!#'>
 		<a href='#!URL!#'>#!TITLE!#</a>
 		&ndash;
 		<span class='description'>#!DESCRIPTION!#</span>
 		<em>#!SOURCE!#</em>
 	  </p>
-<?php
+	
+	  <?php
 		$default_html = ob_get_clean();
 
 		if (get_option("argo_link_roundups_custom_html") != "") {
@@ -563,6 +572,7 @@ class ArgoLinks {
 		$argo_html = str_replace("#!TITLE!#",$title,$argo_html);
 		$argo_html = str_replace("#!DESCRIPTION!#",$description,$argo_html);
 		$argo_html = str_replace("#!SOURCE!#",$source,$argo_html);
+		$argo_html = str_replace("#!STYLE!#",$style,$argo_html);
 		return $argo_html;
 	}
 
@@ -573,10 +583,38 @@ class ArgoLinks {
 	 */
 	public static function rounduplink_shortcode( $atts ) {
 
-		$a = shortcode_atts( array( 'id' => '', 'title' => '' ), $atts );
-
+		$a = shortcode_atts( 
+			array( 'id' => '', 
+				   'title' => '', 
+				   'style' => '' ), 
+			$atts,
+		);
+		
+		// check if a link has style like 'sponsored'
+		if(!empty($a['style'])) { 
+		
+			$custom_css = get_option('argo_link_roundups_sponsored_style');
+			
+			// check for custom css
+			if(!empty($custom_css)) {
+				$output_style = $custom_css;
+			}
+			
+			// set a default style for the plugin
+			else {
+				$output_style = 'font-style:italics;background:#aaa;';
+			}
+			
+			$link_style = $output_style; // we pass this variable below
+			
+		}
+		
+		else { // if no style="" in shortcode, display nothing
+			$link_style='';
+		}
+		
 		if( $a['id'] != null )
-			return self::get_html( $a['id'] );
+			return self::get_html( $a['id'], $link_style ); // id and style
 		else
 			return '';
 		

--- a/argo-links-class.php
+++ b/argo-links-class.php
@@ -589,7 +589,7 @@ class ArgoLinks {
 			array( 'id' => '', 
 				   'title' => '', 
 				   'style' => '' ), 
-			$atts,
+			$atts
 		);
 		
 		// check if a link has style like 'sponsored'

--- a/argo-links-class.php
+++ b/argo-links-class.php
@@ -327,14 +327,14 @@ class ArgoLinks {
 
 	 <div class="card pressthis">
 	<h3><?php _e('Link This') ?></h3>
-	<p><?php _e( 'Link This is a little bookmarklet that lets you save your current page as a Saved Link.' );?></p>
-	<p><?php _e( 'The bookmarklet tries to automatically fills the URL, Title, Source out for you.' ); ?></p>
+	<p><?php _e( 'Link This is a little bookmarklet that lets you send Saved Links to your WordPress Dashboard while browsing the web.' );?></p>
+	<p><?php _e( 'Click Link This!, and a new WordPress window will popup, attempting to prefill Title, URL and Source information.' ); ?></p>
 
 
 	<form>
 		<h3><?php _e( 'Install Link This' ); ?></h3>
-		<h4><?php _e( 'Bookmarklet' ); ?></h4>
-		<p><?php _e( 'Drag the bookmarklet below to your bookmarks bar. Then, when you&#8217;re on a page you want to share, simply &#8220;press&#8221; it.' ); ?></p>
+		<h4><?php _e( 'Browser Bookmarklet' ); ?></h4>
+		<p><?php _e( 'Drag the Link This! bookmarklet below to your web browser\'s Bookmarks Toolbar.<br /><em>If you can\'t drag, click the Clipboard.</em>' ); ?></p>
 
 		<p class="pressthis-bookmarklet-wrapper">
 			<a class="pressthis-bookmarklet" onclick="return false;" href="<?php echo Argo_This_Button::shortcut_link(); ?>"><span><?php _e( 'Link This!' ); ?></span></a>
@@ -353,7 +353,7 @@ class ArgoLinks {
 			</p>
 		</div>
 
-		<h4><?php _e( 'Direct link (best for mobile)' ); ?></h4>
+		<h4><?php _e( 'Direct link (best for mobile and tablets)' ); ?></h4>
 		<p><?php _e( 'Follow the link to open Link This. Then add it to your device&#8217;s bookmarks or home screen.' ); ?></p>
 
 		<p>

--- a/templates/options.php
+++ b/templates/options.php
@@ -17,20 +17,42 @@ EOT;
 		<div class="options-wrapper">
 			<div id="rename" class="card">
 				<h3>Rename Link Roundups</h3>
+				<p>You might call it a Daily Digest. Recap. Team Newsletter. Etc.</p> 
+				<p>Modify the Post Type Name displayed in the WordPress Dashboard Menus and Pages and the Post Type Slug (<a href="http://codex.wordpress.org/Glossary#Post_Slug">learn more</a>) used in the public URL for each Link Roundup post.</p>
 				<h4>Custom Name</h4>
-				<h5 style="margin-bottom:0;padding-bottom:0;">Singular (Roundup)</h5>
+				<h5 style="margin-bottom:0;padding-bottom:0;">Singular (Default: Link Roundup)</h5>
 				<input type="text" name="link_roundups_custom_name_singular" value="<?php echo get_option('link_roundups_custom_name_singular'); ?>" />
-				<h5 style="margin-bottom:0;padding-bottom:0;">Plural (Link Roundups)</h5>
+				<h5 style="margin-bottom:0;padding-bottom:0;">Plural (Default: Link Roundups)</h5>
 				<input type="text" name="link_roundups_custom_name_plural" value="<?php echo get_option('link_roundups_custom_name_plural'); ?>" />
 
-				<h4>Custom URL Slug</h4>
-				<p>Must be lowercase with no spaces -- dashes allowed.</p>
+				<h4 style="margin-bottom:2px;padding-bottom:2px;">Custom URL Slug</h4>
+				<h5 style="margin:0;padding:0;">Current URL Slug for Link Roundups:</h5>
+				<code style="display:block;margin:0.33em 0;">
+					<?php echo get_site_url(); ?>/
+					<strong><?php 
+					$custom_slug_setting = get_option('argo_link_roundups_custom_url');
+					
+					if(!empty($custom_slug_setting)) { 
+						$current_slug = $custom_slug_setting; // apply custom slug
+					} else {
+						$current_slug = 'roundup'; // set plugin default to roundup
+					}
+					echo $current_slug; ?>
+					</strong>/random-roundup/</code>
 				<?php $custom_slug = get_option('argo_link_roundups_custom_url'); ?>
-				<input type="text" name="argo_link_roundups_custom_url" value="<?php echo get_option('argo_link_roundups_custom_url'); ?>" />
-				<br /><br /><code style="display:block;"><?php echo get_site_url(); ?>/<strong>roundup</strong>/random-saved-link/</code><br />
+				<input type="text" name="argo_link_roundups_custom_url" value="<?php echo $custom_slug; ?>" />
+				<p>Must be lowercase with no spaces or special characters -- dashes allowed.</p>
+				
+				<?php // echo get_option('argo_link_roundups_custom_url'); ?>
 			    	<p><strong>IMPORTANT</strong>: Whenever you define a new Custom URL Slug, you <strong>must</strong> also update your 
 			    	<a href="<?php echo admin_url( '/options-permalink.php' ); ?>"><strong>Permalink Settings</strong></a>.
 			    	</p>
+			    	<label for="argo_link_roundups_permalink_flush">
+							Update the WordPress Permalink Settings?
+							<input type="checkbox" name="argo_link_roundups_permalink_flush"
+								<?php checked(get_option('argo_link_roundups_permalink_flush'), 'on', true); ?> />
+					</label><br />
+					<em>This is checked automatically if you change the slug setting above.<br />You may disable to manually save or modify your Permalinks/.htaccess.</em>
 				
 			</div>
 			<div id="html" class="card">

--- a/templates/options.php
+++ b/templates/options.php
@@ -9,29 +9,33 @@ EOT;
 	<?php settings_errors(); ?>
 	
 	<h4>Documentation</h4>
-	Read about these settings and using this plugin in <a href="https://github.com/INN/link-roundups/tree/master/docs">the documentation on GitHub</a>.
-
+	<p>Read about these settings and using this plugin in <a href="https://github.com/INN/link-roundups/tree/master/docs">the documentation on GitHub</a>.</p>
+	<a href="#rename"><strong>Rename Link Roundups</strong></a> | <a href="#html"><strong>Custom HTML for Displaying Links</strong></a> | <a href="#mailchimp"><strong>Mailchimp Integration</strong></a>
 	<form method="post" action="options.php">
 		<?php settings_fields( 'argolinkroundups-settings-group' ); ?>
 		<?php do_settings_fields( 'argolinkroundups-settings-group', null ); ?>
 		<div class="options-wrapper">
-			<div class="card">
+			<div id="rename" class="card">
 				<h3>Rename Link Roundups</h3>
-				<h4>Custom URL Slug</h4>
-				<p>Provide a new post slug (lowercase, no spaces, dashes allowed)</p>
-				<input type="text" name="argo_link_roundups_custom_url" value="<?php echo get_option('argo_link_roundups_custom_url'); ?>" />
-				<br /><br /><code style="display:block;"><?php echo get_site_url(); ?>/<strong>roundup</strong>/random-saved-link/</code><br />
-			    	<strong>IMPORTANT</strong>: Whenever you define a new custom slug, you <strong>must</strong> update your Permalink Settings (Settings --> Permalinks).
 				<h4>Custom Name</h4>
-				<h5 style="margin-bottom:0;padding-bottom:0;">Singular (Post)</h5>
+				<h5 style="margin-bottom:0;padding-bottom:0;">Singular (Roundup)</h5>
 				<input type="text" name="link_roundups_custom_name_singular" value="<?php echo get_option('link_roundups_custom_name_singular'); ?>" />
-				<h5 style="margin-bottom:0;padding-bottom:0;">Plural (Posts)</h5>
+				<h5 style="margin-bottom:0;padding-bottom:0;">Plural (Link Roundups)</h5>
 				<input type="text" name="link_roundups_custom_name_plural" value="<?php echo get_option('link_roundups_custom_name_plural'); ?>" />
 
+				<h4>Custom URL Slug</h4>
+				<p>Must be lowercase with no spaces -- dashes allowed.</p>
+				<?php $custom_slug = get_option('argo_link_roundups_custom_url'); ?>
+				<input type="text" name="argo_link_roundups_custom_url" value="<?php echo get_option('argo_link_roundups_custom_url'); ?>" />
+				<br /><br /><code style="display:block;"><?php echo get_site_url(); ?>/<strong>roundup</strong>/random-saved-link/</code><br />
+			    	<p><strong>IMPORTANT</strong>: Whenever you define a new Custom URL Slug, you <strong>must</strong> also update your 
+			    	<a href="<?php echo admin_url( '/options-permalink.php' ); ?>"><strong>Permalink Settings</strong></a>.
+			    	</p>
+				
 			</div>
-			<div class="card">
-				<h3>Custom HTML</h3>
-				<p>Modify the output of Saved Links sent to the editor.</p>
+			<div id="html" class="card">
+				<h3>Custom HTML for Displaying Links</h3>
+				<p>Modify the display and style of Saved Links.</p>
 				<textarea name="argo_link_roundups_custom_html" cols='70' rows='6' ><?php echo (get_option('argo_link_roundups_custom_html') != "" ? get_option('argo_link_roundups_custom_html')	: $default_html); ?></textarea>
 				<em>Single quotes are REQUIRED in Custom HTML. Double quotes will be automatically converted to single quotes before use.</em><br /><br />
 				The following tags will be replaced with the URL, Title, Description, and Source automatically when the Saved Link is pushed into the Post Editor.<br />
@@ -44,10 +48,10 @@ EOT;
 				<h4 style="margin-bottom:0;padding-bottom:0;">Default HTML</h4><br />
 				<code><?php echo htmlspecialchars($default_html); ?></code><br />
 				<h4>Style Links</h4>
-				Add custom styles to your theme's CSS based on selectors and structure above.
+				<p>Add custom styles to your theme's CSS based on selectors and structure above.</p>
 			</div>
 			
-			<div class="card">
+			<div id="mailchimp" class="card">
 				<h3>MailChimp Integration</h3>
 					<p style="margin-bottom:5px;">
 						<label for="argo_link_roundups_use_mailchimp_integration">
@@ -64,11 +68,9 @@ EOT;
 								placeholder="Mailchimp API Key" />
 						</label>
 					</p>
-					<p><a href="http://kb.mailchimp.com/accounts/management/about-api-keys#Find-or-Generate-Your-API-Key">Finding your key</a></p>
-				</div>
+					<p><a href="http://kb.mailchimp.com/accounts/management/about-api-keys#Find-or-Generate-Your-API-Key">Find your MailChimp API Key</a></p>
 			<?php if ((bool) get_option('argo_link_roundups_use_mailchimp_integration') && !empty($templates)) { ?>
-			<div class="card">
-				<h3>MailChimp Templates</h3>
+				<h4>MailChimp Templates</h4>
 					<select name="argo_link_mailchimp_template">
 						<option value=""></option>
 						<?php foreach ($templates['user'] as $key => $template) { ?>
@@ -76,11 +78,9 @@ EOT;
 						<?php } ?>
 					</select>
 					<p>Choose a MailChimp template to use as the basis for Argo Link Roundup email campaigns.</p>
-			</div>
 			<?php } ?>
 			<?php if ((bool) get_option('argo_link_roundups_use_mailchimp_integration') && !empty($lists)) { ?>
-			<div class="card"
-				<h3>MailChimp Lists</h3>
+				<h4>MailChimp Lists</h4>
 					<select name="argo_link_mailchimp_list">
 						<option value=""></option>
 						<?php foreach ($lists['data'] as $key => $list) { ?>
@@ -88,8 +88,10 @@ EOT;
 						<?php } ?>
 					</select>
 					<p>Choose a MailChimp list that your Argo Link Roundup email campaigns will be sent to.</p>
-			</div>
 			<?php } ?>
+				</div>
+
+
 		<p class="submit">
 			<input type="submit" class="button-primary" value="<?php _e('Save Changes') ?>" />
 		</p>

--- a/templates/options.php
+++ b/templates/options.php
@@ -1,6 +1,6 @@
 <?php
 $default_html = <<<EOT
-<p class='link-roundup'><a href='#!URL!#'>#!TITLE!#</a> &ndash; <span class='description'>#!DESCRIPTION!#</span> <em>#!SOURCE!#</em></p>
+<p class='link-roundup' style='#!STYLE!#'><a href='#!URL!#'>#!TITLE!#</a> &ndash; <span class='description'>#!DESCRIPTION!#</span> <em>#!SOURCE!#</em></p>
 EOT;
 ?>
 <div class="wrap">
@@ -44,10 +44,14 @@ EOT;
 				<li><code>#!TITLE!#</code></li>
 				<li><code>#!DESCRIPTION!#</code></li>
 				<li><code>#!SOURCE!#</code></li>
+				<li><code>#!STYLE!#</code><em><small>Intended for the paragraph wrapper</small></em></li>
 				</ul></blockquote>
 				<h4 style="margin-bottom:0;padding-bottom:0;">Default HTML</h4><br />
 				<code><?php echo htmlspecialchars($default_html); ?></code><br />
-				<h4>Style Links</h4>
+				<h3>Custom Sponsored Link Inline CSS (#!STYLE!#)</h3>
+				<p>Use style to separate sponsored links from your standard links.<br /><br />Inside the [rounduplink ...] shortcode in the Link Roundups Editor, add <code>style="sponsored"</code>. CSS written below will be included inline so it can display in both WordPress and Mailchimp with ease.</p>
+				<textarea name="argo_link_roundups_sponsored_style" cols='70' rows='6' ><?php echo (get_option('argo_link_roundups_sponsored_style') != "" ? get_option('argo_link_roundups_sponsored_style') : null); ?></textarea>
+				<h4>General Styling of Saved Links Output</h4>
 				<p>Add custom styles to your theme's CSS based on selectors and structure above.</p>
 			</div>
 			

--- a/templates/options.php
+++ b/templates/options.php
@@ -14,43 +14,41 @@ EOT;
 	<form method="post" action="options.php">
 		<?php settings_fields( 'argolinkroundups-settings-group' ); ?>
 		<?php do_settings_fields( 'argolinkroundups-settings-group', null ); ?>
-		<table class="form-table">
-			<tr valign="top">
-				<th scope="row">Custom URL Slug</th>
-				<td><input type="text" name="argo_link_roundups_custom_url" value="<?php echo get_option('argo_link_roundups_custom_url'); ?>" /></td>
-			</tr>
-			<tr>
-				<td></td>
-				<td><p>Overwrites <code>roundup</code> as the slug in Link Roundup URLs.</p><br />
-			    <strong>IMPORTANT</strong>: After saving a custom slug, you <strong>must</strong> update your Permalink Settings (Settings --> Permalinks).
-				</td>
-			</tr>
-			<tr valign="top">
-				<th scope="row">Custom HTML</th>
-				<td><textarea name="argo_link_roundups_custom_html" cols='100' rows='5' ><?php echo (get_option('argo_link_roundups_custom_html') != "" ? get_option('argo_link_roundups_custom_html')	: $default_html); ?></textarea></td>
-			</tr>
-			<tr>
-				<td></td>
-				<td>
-				<h4 style="margin-top:0;padding-top:0;">Modify the output of Saved Links sent to the editor.</h4>
+		<div class="options-wrapper">
+			<div class="card">
+				<h3>Rename Link Roundups</h3>
+				<h4>Custom URL Slug</h4>
+				<p>Provide a new post slug (lowercase, no spaces, dashes allowed)</p>
+				<input type="text" name="argo_link_roundups_custom_url" value="<?php echo get_option('argo_link_roundups_custom_url'); ?>" />
+				<br /><br /><code style="display:block;"><?php echo get_site_url(); ?>/<strong>roundup</strong>/random-saved-link/</code><br />
+			    	<strong>IMPORTANT</strong>: Whenever you define a new custom slug, you <strong>must</strong> update your Permalink Settings (Settings --> Permalinks).
+				<h4>Custom Name</h4>
+				<h5 style="margin-bottom:0;padding-bottom:0;">Singular (Post)</h5>
+				<input type="text" name="link_roundups_custom_name_singular" value="<?php echo get_option('link_roundups_custom_name_singular'); ?>" />
+				<h5 style="margin-bottom:0;padding-bottom:0;">Plural (Posts)</h5>
+				<input type="text" name="link_roundups_custom_name_plural" value="<?php echo get_option('link_roundups_custom_name_plural'); ?>" />
+
+			</div>
+			<div class="card">
+				<h3>Custom HTML</h3>
+				<p>Modify the output of Saved Links sent to the editor.</p>
+				<textarea name="argo_link_roundups_custom_html" cols='70' rows='6' ><?php echo (get_option('argo_link_roundups_custom_html') != "" ? get_option('argo_link_roundups_custom_html')	: $default_html); ?></textarea>
 				<em>Single quotes are REQUIRED in Custom HTML. Double quotes will be automatically converted to single quotes before use.</em><br /><br />
 				The following tags will be replaced with the URL, Title, Description, and Source automatically when the Saved Link is pushed into the Post Editor.<br />
-				<ul style="list-style-type:square;">
+				<blockquote><ul style="list-style-type:square;">
 				<li><code>#!URL!#</code></li>
 				<li><code>#!TITLE!#</code></li>
 				<li><code>#!DESCRIPTION!#</code></li>
 				<li><code>#!SOURCE!#</code></li>
-				</ul>
-				<br /><br />
+				</ul></blockquote>
 				<h4 style="margin-bottom:0;padding-bottom:0;">Default HTML</h4><br />
 				<code><?php echo htmlspecialchars($default_html); ?></code><br />
-				<h5>Style Links</h5>
+				<h4>Style Links</h4>
 				Add custom styles to your theme's CSS based on selectors and structure above.
-				</td>
-			</tr>
-			<tr>
-				<th scope="row">MailChimp Integration</th>
-				<td>
+			</div>
+			
+			<div class="card">
+				<h3>MailChimp Integration</h3>
 					<p style="margin-bottom:5px;">
 						<label for="argo_link_roundups_use_mailchimp_integration">
 							Enable MailChimp Integration?
@@ -67,12 +65,10 @@ EOT;
 						</label>
 					</p>
 					<p><a href="http://kb.mailchimp.com/accounts/management/about-api-keys#Find-or-Generate-Your-API-Key">Finding your key</a></p>
-				</td>
-			</tr>
+				</div>
 			<?php if ((bool) get_option('argo_link_roundups_use_mailchimp_integration') && !empty($templates)) { ?>
-			<tr>
-				<th scope="row">MailChimp Templates</th>
-				<td>
+			<div class="card">
+				<h3>MailChimp Templates</h3>
 					<select name="argo_link_mailchimp_template">
 						<option value=""></option>
 						<?php foreach ($templates['user'] as $key => $template) { ?>
@@ -80,13 +76,11 @@ EOT;
 						<?php } ?>
 					</select>
 					<p>Choose a MailChimp template to use as the basis for Argo Link Roundup email campaigns.</p>
-				</td>
-			</tr>
+			</div>
 			<?php } ?>
 			<?php if ((bool) get_option('argo_link_roundups_use_mailchimp_integration') && !empty($lists)) { ?>
-			<tr>
-				<th scope="row">MailChimp Lists</th>
-				<td>
+			<div class="card"
+				<h3>MailChimp Lists</h3>
 					<select name="argo_link_mailchimp_list">
 						<option value=""></option>
 						<?php foreach ($lists['data'] as $key => $list) { ?>
@@ -94,11 +88,8 @@ EOT;
 						<?php } ?>
 					</select>
 					<p>Choose a MailChimp list that your Argo Link Roundup email campaigns will be sent to.</p>
-				</td>
-			</tr>
+			</div>
 			<?php } ?>
-		</table>
-
 		<p class="submit">
 			<input type="submit" class="button-primary" value="<?php _e('Save Changes') ?>" />
 		</p>


### PR DESCRIPTION
Cleanup Options Page significantly (so long old school ```<tables>```, hello ```<div class="cards">```) because it sounds like we're adding more settings for link tracking down the line too.
<img width="618" alt="screen shot 2015-07-09 at 3 51 06 pm" src="https://cloud.githubusercontent.com/assets/9565066/8608715/74330cb0-2652-11e5-92d1-f965a8b6572a.png">

Overwrite labels, title and slug in WordPress for Link Roundups (i.e. to Digests).
<img width="985" alt="screen shot 2015-07-09 at 3 51 26 pm" src="https://cloud.githubusercontent.com/assets/9565066/8608707/65352a2c-2652-11e5-989a-21dd5f34e53d.png">


