### PR TITLE
Rearrange the tests directory and stub out test functions for everything

### DIFF
--- a/inc/lroundups/browser-bookmark.php
+++ b/inc/lroundups/browser-bookmark.php
@@ -222,7 +222,7 @@ class Save_To_Site_Button {
 
 		self::manageAjaxRequest();
 
-		}
+	}
 
 	/**
 	 * Returns the default title value for this link.

--- a/inc/updates/functions.php
+++ b/inc/updates/functions.php
@@ -9,10 +9,8 @@
  * @since 0.3
  */
 function lroundups_update_post_terms($to,$from) {
-
 	_lroundups_convert_posts('argolinkroundups','roundup');
 	_lroundups_convert_posts('argolinks','rounduplink');
-
 }
 add_action('lroundups_update_0.3','lroundups_update_post_terms',10,2);
 
@@ -26,13 +24,9 @@ function _lroundups_convert_posts($old_post_type,$new_post_type) {
 	global $wpdb;
 	$wpdb->query( $wpdb->prepare(
 		"UPDATE  $wpdb->posts
-    		SET  `post_type` =  %s
-    		WHERE  `post_type` = %s;"
+		SET  `post_type` =  %s
+		WHERE  `post_type` = %s;"
 		, $new_post_type, $old_post_type )
 	);
 
 }
-
-
-
-?>

--- a/tests/inc/lroundups/test-browser-bookmark.php
+++ b/tests/inc/lroundups/test-browser-bookmark.php
@@ -1,0 +1,44 @@
+<?php
+
+class Save_To_Site_Button_Tests extends WP_UnitTestCase {
+
+	function test_default_imgUrl() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_default_source() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_default_link() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_default_description() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_default_title() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_load() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_redirect() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_shortcut_link() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_manageAjaxRequest() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_init() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+}

--- a/tests/inc/lroundups/test-class-lroundups.php
+++ b/tests/inc/lroundups/test-class-lroundups.php
@@ -1,6 +1,6 @@
 <?php
 
-class LRoundupsTestFunctions extends WP_UnitTestCase {
+class LRoundupsClassTest extends WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 

--- a/tests/inc/lroundups/test-mailchimp-admin.php
+++ b/tests/inc/lroundups/test-mailchimp-admin.php
@@ -1,6 +1,6 @@
 <?php
 
-class SavedLinksTestFunctions extends WP_UnitTestCase {
+class MailChimpAdminTests extends WP_UnitTestCase {
 
 	function setUp() {
 		parent::setUp();
@@ -23,51 +23,10 @@ class SavedLinksTestFunctions extends WP_UnitTestCase {
 		$screen->post_type = 'roundup';
 	}
 
-	function tearDown() {
-		// Reset global $post object
-		$post = $this->tmp_post;
-		wp_reset_postdata();
-	}
-
-	function test_lroundups_activation() {
-		lroundups_activation();
-		$this->assertTrue(get_option('argolinks_flush'));
-	}
-
-	function test_lroundups_deactivation() {
-		lroundups_activation();
-		lroundups_deactivation();
-		$this->assertFalse(get_option('argolinks_flush'));
-	}
-
-	function test_lroundups_flush_permalinks() {
-		global $wp_rewrite;
-
-		lroundups_activation();
-		$ret = lroundups_flush_permalinks();
-
-		// Testing when it should run
-		$this->assertFalse(get_option('argolinks_flush'), "lroundups_flush_permalinks did not reset the argolinks_flush option");
-		$this->assertTrue($ret);
-		unset($ret);
-
-		// Testing when it should not run
-		$ret = lroundups_flush_permalinks();
-		$this->assertFalse($ret);
-	}
-
 	function test_lroundups_create_mailchimp_campaign_button() {
 		// Test the function output
 		$this->expectOutputRegex('/Create MailChimp Campaign/');
 		lroundups_create_mailchimp_campaign_button();
-	}
-
-	function test_link_roundups_enqueue_assets() {
-		link_roundups_enqueue_assets();
-
-		global $wp_styles, $wp_scripts;
-		$this->assertTrue(!empty($wp_scripts->registered['link-roundups']));
-		$this->assertTrue(!empty($wp_styles->registered['links-common']));
 	}
 
 	function test_lroundups_modal_underscore_template() {
@@ -90,4 +49,9 @@ class SavedLinksTestFunctions extends WP_UnitTestCase {
 		$ret = lroundups_get_mc_api_endpoint();
 		$this->assertEquals($ret, $this->mc_api_endpoint);
 	}
+
+	function test_lroundups_create_mailchimp_campaign() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
 }

--- a/tests/inc/lroundups/test-widget.php
+++ b/tests/inc/lroundups/test-widget.php
@@ -1,0 +1,21 @@
+<?php
+
+class link_roundups_widget_Tests extends WP_UnitTestCase {
+
+	function test_link_roundups_widget () {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_widget() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_update() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_form() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/inc/saved-links/test-class-saved-links.php
+++ b/tests/inc/saved-links/test-class-saved-links.php
@@ -1,0 +1,97 @@
+<?php
+
+class SavedLinksClassTests extends WP_UnitTestCase {
+
+	function test_init() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_plugin_mce_css() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_add_styles() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_register_post_type() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_register_rounduplinks_taxonomy() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_add_custom_post_fields() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_display_custom_fields() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_save_custom_fields() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_media_sideload_image() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_display_custom_columns() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_data_for_custom_columns() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_add_save_to_site_sub_menu() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_build_lroundups_page() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_add_saved_links_widget() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_add_link_roundups_widget() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_the_permalink() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_the_author() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_the_author_posts_link() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_the_content() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_the_excerpt() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_get_html() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_rounduplink_shortcode() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_get_excerpt() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/inc/saved-links/test-display-recent.php
+++ b/tests/inc/saved-links/test-display-recent.php
@@ -1,0 +1,5 @@
+<?php
+
+/*
+ * TODO: Add tests once display-recent.php is written in some way that it can actually be tested.
+ */

--- a/tests/inc/saved-links/test-widget.php
+++ b/tests/inc/saved-links/test-widget.php
@@ -1,0 +1,21 @@
+<?php
+
+class saved_links_widget_Tests extends WP_UnitTestCase {
+
+	function test_saved_links_widget () {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_widget() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_update() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_form() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/inc/test-argo-links-compatability.php
+++ b/tests/inc/test-argo-links-compatability.php
@@ -1,0 +1,9 @@
+<?php
+
+class ArgoLinksCompatibilityTests extends WP_UnitTestCase {
+
+	function test_redirect_argolinks_requests() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/inc/updates/test-functions.php
+++ b/tests/inc/updates/test-functions.php
@@ -1,0 +1,13 @@
+<?php
+
+class UpdateFunctionsTests extends WP_UnitTestCase {
+
+	function test_lroundups_update_post_terms () {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test__lroundups_convert_posts() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/inc/updates/test-index.php
+++ b/tests/inc/updates/test-index.php
@@ -1,0 +1,37 @@
+<?php
+
+class UpdateIndexTests extends WP_UnitTestCase {
+
+	function test_lroundups_perform_update() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_version() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_need_updates() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_update_admin_notice() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_register_update_page () {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_update_page_view() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_update_page_enqueue_js() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_lroundups_ajax_update_database() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/test-link-roundups.php
+++ b/tests/test-link-roundups.php
@@ -1,0 +1,64 @@
+<?php
+
+class LinkRoundupsFunctionsTests extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+		// Set up global $post object
+		$this->savedlinks_post = $this->factory->post->create(array('post_type' => 'roundup'));
+		global $post;
+		$this->tmp_post = $post;
+		$post = get_post($this->savedlinks_post);
+		setup_postdata($post);
+
+		// Mimic the post edit page
+		set_current_screen('post');
+		$screen = get_current_screen();
+		$screen->post_type = 'roundup';
+	}
+
+	function tearDown() {
+		// Reset global $post object
+		$post = $this->tmp_post;
+		wp_reset_postdata();
+	}
+
+	function test_lroundups_activation() {
+		lroundups_activation();
+		$this->assertTrue(get_option('argolinks_flush'));
+	}
+
+	function test_lroundups_deactivation() {
+		lroundups_activation();
+		lroundups_deactivation();
+		$this->assertFalse(get_option('argolinks_flush'));
+	}
+
+	function test_lroundups_flush_permalinks() {
+		global $wp_rewrite;
+
+		lroundups_activation();
+		$ret = lroundups_flush_permalinks();
+
+		// Testing when it should run
+		$this->assertFalse(
+			get_option('argolinks_flush'),
+			"lroundups_flush_permalinks did not reset the argolinks_flush option");
+		$this->assertTrue($ret);
+		unset($ret);
+
+		// Testing when it should not run
+		$ret = lroundups_flush_permalinks();
+		$this->assertFalse($ret);
+	}
+
+	function test_link_roundups_enqueue_assets() {
+		link_roundups_enqueue_assets();
+
+		global $wp_styles, $wp_scripts;
+		$this->assertTrue(!empty($wp_scripts->registered['link-roundups']));
+		$this->assertTrue(!empty($wp_styles->registered['links-common']));
+	}
+
+}


### PR DESCRIPTION
Reorganizes the tests directory to mirror the new layout of the project.

Also, adds stub tests functions for nearly all of the plugin. The majority of tests are skipped, but this gives us at least some idea of coverage and what needs to be done.