### PR TITLE
fix space

### DIFF
--- a/templates/options.php
+++ b/templates/options.php
@@ -1,6 +1,6 @@
 <?php
 $default_html = <<<EOT
-<p class='lr-saved-link#!CLASS!#'><a href='#!URL!#'>#!TITLE!#</a>&ndash;<span class='description'>#!DESCRIPTION!#</span><em>#!SOURCE!#</em></p>
+<p class='lr-saved-link#!CLASS!#'><a href='#!URL!#'>#!TITLE!#</a>&ndash;<span class='description'>#!DESCRIPTION!#</span> <em>#!SOURCE!#</em></p>
 EOT;
 ?>
 <div class="wrap">


### PR DESCRIPTION
the way this is written isn’t good because we’ll have to overwrite this
manually on existing sites that have it saved without unless we add
something to delete the setting following plugin update.

changed:
- default html output in options.php under /templates.