### PR TITLE
Error image import

### DIFF
--- a/inc/lroundups/browser-bookmark.php
+++ b/inc/lroundups/browser-bookmark.php
@@ -186,11 +186,14 @@ class Save_To_Site_Button {
 		}
 
 		self::$imgUrl = '';
+		// if there IS a social URL, set it!
 		if( !empty($meta['ogp']['image']) ) {
 			self::$imgUrl = $meta['ogp']['image'];
 		}
+		// if there ISN'T a social URL, spit error!
 		if( empty($meta['ogp']['image']) ) {
 			// set a temporary transient to explain img import failure
+			// @see class-saved-links.php
 			set_transient('failed_img_import', true, 10);
 		}
 		

--- a/inc/lroundups/browser-bookmark.php
+++ b/inc/lroundups/browser-bookmark.php
@@ -189,7 +189,11 @@ class Save_To_Site_Button {
 		if( !empty($meta['ogp']['image']) ) {
 			self::$imgUrl = $meta['ogp']['image'];
 		}
-
+		if( empty($meta['ogp']['image']) ) {
+			// set a temporary transient to explain img import failure
+			set_transient('failed_img_import', true, 10);
+		}
+		
 		/**
          * Default Link Roundups Values for Custom Meta
          *

--- a/inc/saved-links/class-saved-links.php
+++ b/inc/saved-links/class-saved-links.php
@@ -172,23 +172,37 @@ class SavedLinks {
 	<input type='text' name='lr_source' value='<?php echo $link_source; ?>' style='width:98%;'/></p>
 
 	<?php if( $link_img_src ) { ?>
-		<p><label><?php _e( 'Import featured image:', 'link-roundups' ); ?></label><br />
+		<p><label><?php _e( 'Import Featured Image:', 'link-roundups' ); ?></label><br />
 		<img src="<?php echo $link_img_src ?>" width="300" />
 		<input type='hidden' name='argo_link_img_url' value='<?php echo $link_img_src; ?>'/><br>
-		<input type="checkbox" value="1" name="lr_img" id="lr_img"><label for="lr_img"><?php _e( 'Import as feature image', 'link-roundups' ); ?></label>
+		<input type="checkbox" value="1" name="lr_img" id="lr_img"><label for="lr_img"><?php _e( 'Use social media image?', 'link-roundups' ); ?></label>
 		</p>
-	<?php }
-		// did the social media image fail to import?
-		// @see browser-bookmark.php -- function load() for transient set
-		if( get_transient('failed_img_import') === true) {
-		  	// first we must delete the transient
-			delete_transient('failed_img_import');
-		    // now lets return the error
-		    // no matter where we spit this out, WordPress CSS yanks this div and spits out
-		    // at the top of the singular post edit screen
-			echo '<div class="error settings-error notice">' . __('<h3>Failed to Import Social Media Image</h3><p>Please upload an image manually.</p>','link-roundups') . '</div>';
+	<?php } else {
+				
+				// did the social media image fail to import?
+				// @see browser-bookmark.php -- function load() for transient set
+				if( get_transient('failed_img_import') === true ) {
+		  			// first delete the transient
+					delete_transient('failed_img_import');
+		    		// check transient is gone as this may get set frequently by multiple 
+		    		if( get_transient('failed_img_import') !== true) {
+					//double-check the image field is blank
+					$screen = get_current_screen();
+					// checking that we're in post-new.php, otherwise notice will fire incessently
+					if ( 'add' === $screen->action && empty($link_img_src) ) {
+						// no matter where we spit this out, WordPress CSS yanks this div and spits out
+		    			// at the top of the singular post edit screen
+						echo '<div class="error settings-error notice">' . __('<h3>Failed to Import a Social Media Image for Featured Image</h3><p>Please upload an image manually.</h3>','link-roundups') . '</div>';
+						
+					}
+
+				}
+				else {
+				   echo '<div class="error settings-error notice">' . __('<h3>Transient didn\'t delete. Try refreshing, but this likely indicates an issue with your WordPress installation.</h3>','link-roundups') . '</div>';
+
+				}
+	      }
 		}
-	
 	}
 
 	/**

--- a/inc/saved-links/class-saved-links.php
+++ b/inc/saved-links/class-saved-links.php
@@ -178,6 +178,17 @@ class SavedLinks {
 		<input type="checkbox" value="1" name="lr_img" id="lr_img"><label for="lr_img"><?php _e( 'Import as feature image', 'link-roundups' ); ?></label>
 		</p>
 	<?php }
+		// did the social media image fail to import?
+		// @see browser-bookmark.php -- function load() for transient set
+		if( get_transient('failed_img_import') === true) {
+		  	// first we must delete the transient
+			delete_transient('failed_img_import');
+		    // now lets return the error
+		    // no matter where we spit this out, WordPress CSS yanks this div and spits out
+		    // at the top of the singular post edit screen
+			echo '<div class="error settings-error notice">' . __('<h3>Failed to Import Social Media Image</h3><p>Please upload an image manually.</p>','link-roundups') . '</div>';
+		}
+	
 	}
 
 	/**


### PR DESCRIPTION
Resolves issue #26.

This pull modifies:
- bookmark file
- class-saved-link.php

During the scraping function (in bookmark file), there's now a transient set when no social media image meta tag is defined in headers. Set for 10 seconds. *Technically sitewide so if two people manage to hit server at same millisecond there could be problems...*

Then function in class-saved-link is checking if the transient is set, if so it deletes the transient which triggers an error only on post-new.php. There are also checks in place to check that the transient has been deleted and an error will spit out just incase.