### PR TITLE
Add a way of specifying admin notices that will survive saving a link post

### DIFF
--- a/link-roundups.php
+++ b/link-roundups.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 Plugin Name: Link Roundups
 Plugin URI: https://github.com/INN/link-roundups

--- a/tests/inc/saved-links/test-class-saved-links.php
+++ b/tests/inc/saved-links/test-class-saved-links.php
@@ -94,4 +94,16 @@ class SavedLinksClassTests extends WP_UnitTestCase {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
+	function test_add_notice() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_add_notice_query_var() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_admin_notices() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
 }


### PR DESCRIPTION
WordPress uses a redirect after the `save_post` hook, which means that adding notices via the standard `admin_notices` hook won't work as expected when the redirect kicks in.

This pull request makes it possible to add notices by using `$_GET` parameters.

This is meant to address #26 -- provide a way of notifying the user when we're unable to import featured images for saved links.

I'm proposing this as an alternative to the method @dryanmedia suggested in #90.