### PR TITLE
Removes typoed WP_Query arg in the Link Roundups widget

### DIFF
--- a/inc/lroundups/widget.php
+++ b/inc/lroundups/widget.php
@@ -25,7 +25,6 @@ class link_roundups_widget extends WP_Widget {
 			$query_args = array (
 				'post__not_in' 	=> get_option( 'sticky_posts' ),
 				'showposts' 	=> $instance['num_posts'],
-				'exceprt'		=> $instance['show_excerpt'],
 				'post_type' 	=> 'post',
 				'post_status'	=> 'publish'
 			);


### PR DESCRIPTION
`excerpt` isn't a WP_Query argument, so this line wouldn't affect the query even if it were spelled correctly.

This isn't high priority, as the argument currently has no affect on the query. it's just removing a useless line of code.

For #102.