### PR TITLE
Update widgets for latest PHP constructor styles

### DIFF
--- a/inc/lroundups/widget.php
+++ b/inc/lroundups/widget.php
@@ -5,12 +5,12 @@
  */
 class link_roundups_widget extends WP_Widget {
 
-	function link_roundups_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'link-roundups',
 			'description' 	=> 'Show your most recent link roundups in the sidebar', 'link-roundups'
 		);
-		$this->WP_Widget( 'link_roundups_widget', __( 'Link Roundups Widget', 'link-roundups' ), $widget_ops );
+		parent::__construct(  'link_roundups_widget', __( 'Link Roundups Widget', 'link-roundups' ), $widget_ops );
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/saved-links/widget.php
+++ b/inc/saved-links/widget.php
@@ -4,7 +4,7 @@
  */
 class saved_links_widget extends WP_Widget {
 
-	function saved_links_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'saved-links',
 			'description' 	=> __( 'Show your most recently saved links in a sidebar widget', 'link-roundups' )


### PR DESCRIPTION
@rnagle This removes same PHP 4 style constructors as the PR on Largo that are being deprecated in 4.4. We should update the WP.org copy before the mid-December(?) release.
https://make.wordpress.org/core/version-4-4-project-schedule/