### PR TITLE
Option to have target="_blank" to open links in new windows

### DIFF
--- a/inc/saved-links/widget.php
+++ b/inc/saved-links/widget.php
@@ -67,17 +67,15 @@ class saved_links_widget extends WP_Widget {
 					if ( isset($custom["lr_source"][0] ) ) {
 						$lr_source = '<p class="source">' . __('Source: ', 'link-roundups') . '<span>';
 						if ( !empty( $custom["lr_url"][0] ) ) {
-							$lr_output .= '<a href="' . $custom["lr_url"][0] . '" ';
+							$lr_source .= '<a href="' . $custom["lr_url"][0] . '" ';
 							if ( $instance['new_window'] == 'on' ) {
-								$output .= 'target="_blank" ';
+								$lr_source .= 'target="_blank" ';
 							}
-							$lr_output .= '>' . $custom["lr_source"][0] . '</a>';
+							$lr_source .= '>' . $custom["lr_source"][0] . '</a>';
 						} else {
-							var_log("meh");
 							$lr_source .= $custom["lr_source"][0];
 						}
 						$lr_source .= '</span></p>';
-						var_log($lr_source);
 						echo $lr_source;
 					}
 				?>


### PR DESCRIPTION
## Changes

- Adds option to Saved Links List Widget settings to have links open in new tab. The option defaults to checked.
- Adds `target="_blank"` to the saved link in the widget output. If, for some reason, a saved link does not have a link, then the link will be to the current page via `get_the_title()` (and yes, that's a possibility)

## Why

[WE-73](http://jira.inn.org/browse/WE-73): requested feature