### PR TITLE
Filter Largo to use the link roundups partials.

### DIFF
--- a/inc/compatibility-largo.php
+++ b/inc/compatibility-largo.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Functions adding compatibility to INN's Largo theme
+ *
+ * @link https://github.com/INN/Largo
+ * @since 0.2
+ */
+
+/**
+ * Use partials/content-rounduplink.php for the rounduplink archive LMP
+ *
+ */
+function lr_lmp_choose_partial($partial, $post_query) {
+	var_log($partial);
+	if ( is_object($post_query) && property_exists( $post_query, 'query_vars')) {
+		$post_query = $post_query->query_vars;
+	}
+
+	if ( isset($post_query['post_type']) && $post_query['post_type'] == 'rounduplink' ) {
+		$partial = 'rounduplink';
+	}
+	return $partial;
+}
+add_filter( 'largo_lmp_template_partial', 'lr_lmp_choose_partial', 10, 2);
+
+/**
+ * Use partials/content-rounduplink.php for the search LMP.
+ */
+function lr_largo_partial_by_post_type($partial, $post_type, $context) {
+	if ( $post_type == 'rounduplink' ) {
+		$partial = 'rounduplink';
+	}
+	return $partial;
+}
+add_filter('largo_partial_by_post_type', 'lr_largo_partial_by_post_type', 10, 3);

--- a/link-roundups.php
+++ b/link-roundups.php
@@ -49,6 +49,12 @@ require_once(__DIR__ . '/inc/compatibility.php');
 
 
 /**
+ * Add compatibility filters for INN/Largo
+ */
+require_once(__DIR__ . '/inc/compatibility-largo.php');
+
+
+/**
  * Initialize the plugin using its init() function
  */
 LRoundups::init();


### PR DESCRIPTION
## Changes

- Creates `inc/compatibility-largo.php` to hold the Largo functions.
- Filters `largo_lmp_template_partial` and `largo_partial_by_post_type` to return `rounduplink` or `roundup`

## Why

These filters are in the plugin so that they will not be active unless the plugin is active and the post types are registered.

For the full details, see the companion Largo pull request https://github.com/INN/Largo/pull/1122

For http://jira.inn.org/browse/WE-90