### PR TITLE
Database Upgrade Fixes & Improvements

### DIFF
--- a/inc/updates/functions.php
+++ b/inc/updates/functions.php
@@ -39,7 +39,7 @@ function lroundups_migrate_options() {
 		);
 		$old_value = get_option( $old_option );
 
-		if ( ! get_option( $new_option ) ) {
+		if ( $old_value ) {
 			$result = update_option( $new_option, $old_value );
 		}
 
@@ -49,7 +49,7 @@ function lroundups_migrate_options() {
 	}
 }
 add_action( 'lroundups_update_0.3', 'lroundups_migrate_options', 10 );
-lroundups_migrate_options();
+
 /**
  * Update rounduplink post meta in database.
  *

--- a/inc/updates/functions.php
+++ b/inc/updates/functions.php
@@ -34,15 +34,22 @@ function lroundups_migrate_options() {
 	// check for old options and replace the old prefixes with lroundups_
 	foreach ( $old_options as $old_option ) {
 		$new_option = str_replace(
-			array('argo_link_roundups_', 'link_roundups_'), 'lroundups_', $old_option);
-		$old_value = get_option($old_option);
-		$result = update_option($new_option, $old_value);
-		if ($result)
-			delete_option($old_option);
+			array( 'argo_link_roundups_', 'link_roundups_' ),
+			'lroundups_', $old_option
+		);
+		$old_value = get_option( $old_option );
+
+		if ( ! get_option( $new_option ) ) {
+			$result = update_option( $new_option, $old_value );
+		}
+
+		if ( $result ) {
+			delete_option( $old_option );
+		}
 	}
 }
 add_action( 'lroundups_update_0.3', 'lroundups_migrate_options', 10 );
-
+lroundups_migrate_options();
 /**
  * Update rounduplink post meta in database.
  *

--- a/inc/updates/index.php
+++ b/inc/updates/index.php
@@ -117,7 +117,6 @@ function lroundups_need_updates() {
  */
 function lroundups_update_admin_notice() {
 	if ( lroundups_need_updates() && !( isset( $_GET['page'] ) && $_GET['page'] == 'update-lroundups' ) ) {
-var_dump(  );
 	?>
 	<div class="update-nag" style="display: block;">
 		<p><?php

--- a/inc/updates/index.php
+++ b/inc/updates/index.php
@@ -75,7 +75,7 @@ function lroundups_version() {
 
 /**
  * Checks if updates need to be run.
- * Get's lroundups version from db and compares with value in plugin file 
+ * Get's lroundups version from db and compares with value in plugin file
  * @since 0.3
  *
  * @return boolean if updates need to be run
@@ -84,11 +84,20 @@ function lroundups_need_updates() {
 
 	// try to figure out which versions of the options are stored. Implemented in 0.3
 	if ( get_option( 'lroundups_version' ) ) {
+
 		$compare = version_compare( lroundups_version(), get_option( 'lroundups_version' ) );
-		if ( $compare == 1 )
-			return true;
-		else
+
+		// If the database version # is less than the plugin's version
+		if ( $compare == 1 ) {
+			// If the database is version is < the last database update
+			if ( 1 == version_compare( '0.3.2', get_option( 'lroundups_version' ) ) ) {
+				return true;
+			} else {
+				update_option( 'lroundups_version', lroundups_version() );
+			}
+		} else {
 			return false;
+		}
 	}
 
 	// if 'lroundups_version' isn't present, the settings are old!

--- a/inc/updates/index.php
+++ b/inc/updates/index.php
@@ -117,13 +117,22 @@ function lroundups_need_updates() {
  */
 function lroundups_update_admin_notice() {
 	if ( lroundups_need_updates() && !( isset( $_GET['page'] ) && $_GET['page'] == 'update-lroundups' ) ) {
+var_dump(  );
 	?>
 	<div class="update-nag" style="display: block;">
 		<p><?php
-		printf(
-			__('Link Roundups has been updated! IMPORTANT: Please <a href="%s">click here</a> to run a required database upgrade.', 'link-roundups'),
-			admin_url('index.php?page=update-lroundups')
-		); ?></p>
+			if ( current_user_can( 'update_plugins' ) ) {
+				printf(
+					__('Link Roundups has been updated! IMPORTANT: Please <a href="%s">click here</a> to run a required database upgrade.', 'link-roundups'),
+					admin_url('index.php?page=update-lroundups')
+				);
+			} else {
+				printf(
+					__('Link Roundups has been updated! IMPORTANT: Please contact your site administrator to run a required database upgrade.', 'link-roundups'),
+					admin_url('index.php?page=update-lroundups')
+				);
+			}
+		?></p>
 	</div>
 	<?php
 	}

--- a/link-roundups.php
+++ b/link-roundups.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
 Plugin Name: Link Roundups
 Plugin URI: https://github.com/INN/link-roundups
@@ -11,6 +10,15 @@ License: GPLv2
 
 Seeking Link Roundups Post Type functions? They use lroundups instead of link-roundups.
  */
+
+/**
+ * The code that runs during plugin activation.
+ */
+function activate_link_roundups() {
+	$plugin = get_plugin_data( __FILE__ );
+	update_option( 'lroundups_version', $plugin['Version'] );
+}
+register_activation_hook( __FILE__, 'activate_link_roundups' );
 
 /**
  * Mailchimp API and Modal Functions


### PR DESCRIPTION
## Fixes #119 
during upgrade, only update the new setting from the old setting if the new setting is not set

## Fixes #123 
Show a different upgrade notice to users who can't update plugins

## Additional
Database upgrades were required upon plugin activation to add the plugin version to the database - that is no longer required