### PR TITLE
Constructor fix for saved_links_widget

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -47,6 +47,8 @@ Via manual upload:
 
 = 0.5 (in development)
 
+- Fixes the saved_links_widget constructor for error-free PHP7 compatibility. Pull request [#137](https://github.com/INN/link-roundups/pull/137) for issue [#132](https://github.com/INN/link-roundups/issues/132).
+
 = 0.4.1 =
 
 - The default query for Saved Links in the roundup editor is now for the last 30 days

--- a/inc/saved-links/class-saved-links-widget.php
+++ b/inc/saved-links/class-saved-links-widget.php
@@ -6,7 +6,7 @@
  */
 class saved_links_widget extends WP_Widget {
 
-	function saved_links_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'saved-links',
 			'description' 	=> __( 'Show your most recently saved links in a sidebar widget', 'link-roundups' )


### PR DESCRIPTION
## Changes

- Renames the constructor for the `saved_links_widget` class to `__construct` for improved compatibility with modern WordPress and PHP standards.

## Why

For #132.