### PR TITLE
Travis updates: Major bumps to PHP supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ before_script:
     - sed -i "s/yourpasswordhere//" wp-tests-config.php
     - mv wp-tests-config.php "$WP_TESTS_DIR/wp-tests-config.php"
     - cd "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
+    - phpunit --version
 
 script: phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,14 @@ matrix:
         env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.1
         env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      # PHPUnit 7 not supported by WordPress
+      # PHPUnit 7, probably
       - php: 7.2
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.2
         env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.2
         env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      # PHPUnit 8?
+      # PHPUnit 8, probably
       - php: 7.3
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ matrix:
         env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.1
         env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      # PHPUnit 7, probably
-      - php: 7.2
-        env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      # PHPUnit 8, probably
-      - php: 7.3
-        env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 8, based on https://github.com/INN/link-roundups/issues/135#issuecomment-470357566
+      #- php: 7.2
+      #  env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 8, based on https://github.com/INN/link-roundups/issues/135#issuecomment-470357566
+      #- php: 7.3
+      #  env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
 # Only test the develop and master branches for now
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,53 @@
 # Travis CI Configuration File
 
+# Use Travis CI container-based infrastructure
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
 # Tell Travis CI we're using PHP
 language: php
 
 # PHP version used in first build configuration.
-php:
-    - "5.3"
-
-sudo: false
+# https://secure.php.net/supported-versions.php
+# php:
+#    # PHP pre-5.6 is EOL
+#    - "5.6"
+#    # PHP 7.0 is EOL
+#    - "7.1"
+#    - "7.2"
+#    - "7.3"
 
 # WordPress version used in first build configuration.
-env:
-    - WP_VERSION=4.2.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+# env:
+#    - WP_VERSION=4.2.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+
+# for a breakdown of why these versions were chosen, see https://github.com/INN/WP-DS-NPR-API/issues/12#issuecomment-374730094
+matrix:
+    include:
+      # PHPUnit 5
+      - php: 5.6
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
+      - php: 7.1
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 7 not supported by WordPress
+      - php: 7.2
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.2
+        env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.2
+        env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 8?
+      - php: 7.3
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.3
+        env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.3
+        env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
 # Only test the develop and master branches for now
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,8 @@ matrix:
         env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       # PHPUnit 7, probably
       - php: 7.2
-        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 7.2
-        env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 7.2
         env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       # PHPUnit 8, probably
-      - php: 7.3
-        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 7.3
-        env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.3
         env: WP_VERSION=5.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,3 @@ before_script:
     - phpunit --version
 
 script: phpunit
-
-notifications:
-    hipchat:
-        rooms:
-            secure: mrJDwl2LYmWGY6gKUEsSnbGp3mQ8UhVQkb9oBmRSDx9T/hCSDx4Q2KDLo0OqCFIwDB5BevP16vDDWVmsg8Ldwk+Hh0YAmdUqBAXe21+17ojqSIAdQg6LgLrEFEBNVBlPu89xonRMnsai34RDCoRt5c9OLuWgGVMAcTojpQvPiII=

--- a/README.md
+++ b/README.md
@@ -11,57 +11,11 @@ A WordPress plugin to make it easy to collect links from around the web, turn th
 
 ## Overview
 
-The Link Roundup plugin allows you to:
-
-- Curate links
-- Create link roundup posts
-- Optionally send the roundup posts to MailChimp to be distributed to your subscribers
-
-It also includes two widgets:
-
-- A widget to display your recently saved links
-- A widget to display your recent link roundup posts (with the ability to limit by category)
-
-The plugin includes a browser bookmark that you can drag to your browser's bookmark bar, allowing you to save links directly to your WordPress site. This bookmark attempts to pre-fill fields like link title, source, URL and featured image and also allows you to add a description to each link viewable when published on your site.
-
-In its previous life, Link Roundups was called Argo Links.
+See the [overview on WordPress.org](https://wordpress.org/plugins/link-roundups/).
 
 ## Installation
 
-See the [installation instructions on WordPress.org](https://wordpress.org/plugins/link-roundups/#installation)
-
-## Features
-
-#### Saved Links
-![New Saved Link](./docs/img/new-saved-link.png)
-
-Curate links from around the web and save them in WordPress using a handy browser bookmark. You can also add your own descriptions and organize saved links using tags.
-
-#### Saved Links Widget
-
-Display a feed of your recent Saved Links, optionally filtered by tags.
-
-#### Link Roundups
-![Recent Saved Links Panel in Link Roundups Editor](https://raw.githubusercontent.com/INN/link-roundups/master/docs/img/link-roundups-passthru.png)
-
-Build Link Roundup posts using a panel that displays and filters your recent Saved Links. Select the links you want to include and send them to the editor to compose your roundup posts.
-
-#### Link Roundups Widget
-
-Display most recent Link Roundup posts by date. Optionally, limit the roundup posts displayed by category.
-
-#### MailChimp API Integration
-
-Simplify your workflow by sending Link Roundup posts directly to MailChimp. Create a template for your roundups using a number of special template tags and then create a new MailChimp campaign directly from WordPress. You can even include sponsored links.
-
-#### Rename Link Roundups
-
-If you would prefer to call your roundup posts something else (daily digest, for example) you can rename the singular (default: Link Roundup) and plural form (default: Link Roundups) as well as the slug for posts in the Link Roundups custom post type. 
-
-#### Custom HTML for Displaying Links
-
-Link Roundup posts have some default styling for your saved links to make sure your posts look great out of the box. If you'd prefer to modify the HTML output for Save Links or styling for sponsored links, you can do that from the plugin settings.
-
+See the [installation instructions on WordPress.org](https://wordpress.org/plugins/link-roundups/#installation).
 
 ## [Documentation](docs/readme.md)
 
@@ -76,3 +30,5 @@ Link Roundup posts have some default styling for your saved links to make sure y
 For information on the development status of this plugin, check the [development milestones on github](https://github.com/INN/link-roundups/milestones).
 
 If you'd like to contribute to the project, please see our [contributing guidelines](contributing.md).
+
+This plugin depends on [INN/wordpress-mailchimp-tools](https://github.com/INN/wordpress-mailchimp-tools), as well as some components imported via composer. 

--- a/README.txt
+++ b/README.txt
@@ -2,11 +2,13 @@
 Contributors: inn_nerds
 Donate link: https://inn.org/donate
 Tags: newsletters, mailchimp, links, curation, aggregation
-Requires at least: 4.1
-Tested up to: 4.2.3
+Requires at least: 4.2
+Tested up to: 5.1
 Stable tag: 0.5
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Minimum PHP: 5.6
+
 
 Collect links from around the web, turn them into roundup posts and streamline the production of daily/weekly roundup newsletters using MailChimp.
 
@@ -46,6 +48,8 @@ Via manual upload:
 == Changelog ==
 
 = 0.5 (in development)
+
+- Updates Travis automated testing to support PHP 5.6, 7.1, 7.2
 
 = 0.4.1 =
 


### PR DESCRIPTION
## Changes

- updates `travis.yml`, closing https://github.com/INN/link-roundups/issues/135
    - container-based builds for faster build speeds
    - modern PHP versions
    - modern WordPress versions
- Clean up README.md
    - shrug user-facing documentation off to WordPress.org listing
    - begin process of listing dependencies
- Update WordPress.org metadata:
    - bump "tested up to" to 5.1
    - improved install instructions, now including manual install