### PR TITLE
Allow Link Roundups widget to have a linked title

### DIFF
--- a/inc/link-roundups/class-link-roundups-widget.php
+++ b/inc/link-roundups/class-link-roundups-widget.php
@@ -14,8 +14,11 @@ class link_roundups_widget extends WP_Widget {
 	}
 
 	function widget( $args, $instance ) {
+
 		extract( $args );
-		$title = apply_filters( 'widget_title', $instance['title'] );
+		
+		// make it possible for the widget title to be a link
+		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Recent Link Roundups' , 'link-roundups') : $instance['title'], $instance, $this->id_base);
 
 		echo $before_widget;
 


### PR DESCRIPTION
Per issue #104, the Link Roundups widget title was not able to be linked. The `$title` variable has been updated in [inc/link-roundups/class-link-roundups-widget.php](https://github.com/INN/link-roundups/compare/104-allow-link-roundups-widget-title-to-be-linked?expand=1#diff-844d30a45eefb72ba07e20d411acd069) to set the title link if it exists.