### PR TITLE
Fix Link Roundup widget displaying wrong number of stories

### DIFF
--- a/inc/link-roundups/class-link-roundups-widget.php
+++ b/inc/link-roundups/class-link-roundups-widget.php
@@ -14,58 +14,59 @@ class link_roundups_widget extends WP_Widget {
 	}
 
 	function widget( $args, $instance ) {
-
-		extract( $args );
-		
 		// make it possible for the widget title to be a link
 		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Recent Link Roundups' , 'link-roundups') : $instance['title'], $instance, $this->id_base);
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
-		if ( $title )
-			echo $before_title . $title . $after_title;
+		if ( !empty( $title ) ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
 
-			$query_args = array (
-				'post__not_in' 	=> get_option( 'sticky_posts' ),
-				'showposts' 	=> $instance['num_posts'],
-				'post_type' 	=> 'post',
-				'post_status'	=> 'publish'
-			);
-			if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
-			$my_query = new WP_Query( $query_args );
-          		if ( $my_query->have_posts() ) {
-          			while ( $my_query->have_posts() ) : $my_query->the_post();
-          				$custom = get_post_custom( $post->ID ); ?>
-	                  	<div class="post-lead clearfix">
-	                      	<?php
-	                      	// the date
-							$output .= '<span>' . get_the_date( 'F d Y' ) . '</span>';
-	                      	// the headline
-							$output .= '<h4><a href="' . get_permalink() . '">' . get_the_title() . '</a></h4>';
-							// the excerpt
-							$output .= '<p>' . get_the_excerpt() . '</p>';
-							echo $output;
-	                      	?>
+		$query_args = array (
+			'post__not_in' 	=> get_option( 'sticky_posts' ),
+			'posts_per_page' 	=> $instance['num_posts'],
+			'post_type' 	=> 'post',
+			'post_status'	=> 'publish'
+		);
 
-	                  	</div> <!-- /.post-lead -->
-	            <?php
-	            	endwhile;
-	            } else {
-	    			_e( '<p class="error"><strong>You don\'t have any recent links or the Link Roundups plugin is not active.</strong></p>', 'link-roundups' );
-	    		} // end recent links
+		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
 
-    		if ( $instance['linkurl'] !='' ) { ?>
-				<p class="morelink"><a href="<?php echo $instance['linkurl']; ?>"><?php echo $instance['linktext']; ?></a></p>
-			<?php }
-		echo $after_widget;
+		$my_query = new WP_Query( $query_args );
+			if ( $my_query->have_posts() ) {
+				while ( $my_query->have_posts() ) : $my_query->the_post();
+					$custom = get_post_custom( $post->ID ); ?>
+					<div class="post-lead clearfix">
+						<?php
+						// the date
+						$output = '<span>' . get_the_date( 'F d Y' ) . '</span>';
+						// the headline
+						$output .= '<h4><a href="' . get_permalink() . '">' . get_the_title() . '</a></h4>';
+						// the excerpt
+						$output .= '<p>' . get_the_excerpt() . '</p>';
+						echo $output;
+						?>
+
+					</div> <!-- /.post-lead -->
+			<?php
+				endwhile;
+			} else {
+				_e( '<p class="error"><strong>You don\'t have any recent links or the Link Roundups plugin is not active.</strong></p>', 'link-roundups' );
+			} // end recent links
+
+		if ( $instance['linkurl'] !='' ) { ?>
+			<p class="morelink"><a href="<?php echo $instance['linkurl']; ?>"><?php echo $instance['linktext']; ?></a></p>
+		<?php }
+
+		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 		$instance['title'] = strip_tags( $new_instance['title'] );
-		$instance['num_posts'] = strip_tags( $new_instance['num_posts'] );
+		$instance['num_posts'] = intval( strip_tags( $new_instance['num_posts'] ) );
 		$instance['linktext'] = $new_instance['linktext'];
-		$instance['linkurl'] = $new_instance['linkurl'];
+		$instance['linkurl'] = esc_url_raw( $new_instance['linkurl'] );
 		$instance['cat'] = intval( $new_instance['cat'] );
 		return $instance;
 	}


### PR DESCRIPTION
Changes:

- Fixes issue where echo in while loop was incrementing a string-concatenation variable. Resolves https://github.com/INN/link-roundups/issues/112
- Removes an extract();
- Cleans up sanitization and whitespace in the Link Roundups widget