### PR TITLE
check WordPress version to prevent deprecated function warning on WP 4.9+

### DIFF
--- a/inc/link-roundups/class-save-to-site-button.php
+++ b/inc/link-roundups/class-save-to-site-button.php
@@ -70,7 +70,10 @@ class Save_To_Site_Button {
 		// This is the default 'Press This!' button link.
 		$shortcut_link = '';
 
-		if ( function_exists( 'get_shortcut_link' ) ) {
+		if (
+			version_compare( get_bloginfo('version'), '4.9', '<' )
+			&& function_exists( 'get_shortcut_link' )
+		) {
 			$shortcut_link = htmlspecialchars( get_shortcut_link() );
 		}
 


### PR DESCRIPTION
Resolves https://github.com/INN/link-roundups/issues/166