### PR TITLE
1.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A WordPress plugin to make it easy to collect links from around the web, turn them into roundup posts and streamline the production of daily/weekly roundup newsletters using MailChimp. Built and maintained by [INN Labs](https://labs.inn.org).
 
 **Requires at least:** 4.1  
-**Tested up to:** 5.2  
+**Tested up to:** 5.2.1  
 **Stable tag:** See https://github.com/INN/link-roundups/releases
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
@@ -30,7 +30,7 @@ For information on the development status of this plugin, check the [development
 
 If you'd like to contribute to the project, please see our [contributing guidelines](contributing.md).
 
-This plugin depends on [INN/wordpress-mailchimp-tools](https://github.com/INN/wordpress-mailchimp-tools), as well as some components imported via composer. 
+This plugin depends on [INN/wordpress-mailchimp-tools](https://github.com/INN/wordpress-mailchimp-tools), as well as some other components imported via `composer`. For more details, see `composer.json`.
 
 ## Contributors:
 

--- a/README.txt
+++ b/README.txt
@@ -44,6 +44,9 @@ For other installation methods, [see this plugin's installation methods on GitHu
 
 This release contains minor bug fixes for the 1.0.1 release.
 
+- Fixes a syntax error discovered via static analysis that blocked wordpress.org release of version 1.0.0. Pull request [#171](https://github.com/INN/link-roundups/pull/171) for issue [#170](https://github.com/INN/link-roundups/issues/170).
+- Fixes a number of [WordPress code standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#rulesets) issues and undefined variables. Pull request [#175](https://github.com/INN/link-roundups/pull/175) for issues [#174](https://github.com/INN/link-roundups/issues/174) and [#169](https://github.com/INN/link-roundups/issues/169).
+
 = 1.0.0 =
 
 - Tested up to WordPress 5.2 and PHP 7.3

--- a/README.txt
+++ b/README.txt
@@ -40,6 +40,10 @@ For other installation methods, [see this plugin's installation methods on GitHu
 
 == Changelog ==
 
+= 1.0.1 =
+
+This release contains minor bug fixes for the 1.0.1 release.
+
 = 1.0.0 =
 
 - Tested up to WordPress 5.2 and PHP 7.3

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://inn.org/donate
 Tags: newsletters, mailchimp, links, curation, aggregation
 Requires at least: 4.2
 Tested up to: 5.2
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP: 5.6

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "inn/wordpress-mailchimp-tools": "dev-master#4ef8919f2e214ad0493c12405e6c8a263ac7a1c6"
+        "inn/wordpress-mailchimp-tools": "dev-master#152f6a408e587f70fcfd9243bf1e8fa8dac9edcf"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2dff385ba98797520b22558f1a9b7f1",
+    "content-hash": "2d0cb50d78cf6309e49548509efc65c2",
     "packages": [
         {
             "name": "drewm/mailchimp-api",
@@ -56,12 +56,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/INN/wordpress-mailchimp-tools.git",
-                "reference": "4ef8919f2e214ad0493c12405e6c8a263ac7a1c6"
+                "reference": "152f6a408e587f70fcfd9243bf1e8fa8dac9edcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/INN/wordpress-mailchimp-tools/zipball/4ef8919f2e214ad0493c12405e6c8a263ac7a1c6",
-                "reference": "4ef8919f2e214ad0493c12405e6c8a263ac7a1c6",
+                "url": "https://api.github.com/repos/INN/wordpress-mailchimp-tools/zipball/152f6a408e587f70fcfd9243bf1e8fa8dac9edcf",
+                "reference": "152f6a408e587f70fcfd9243bf1e8fa8dac9edcf",
                 "shasum": ""
             },
             "require": {
@@ -95,7 +95,7 @@
                 "api",
                 "email"
             ],
-            "time": "2019-05-16T20:35:15+00:00"
+            "time": "2019-05-24T21:25:42+00:00"
         }
     ],
     "packages-dev": [],

--- a/inc/compatibility-largo.php
+++ b/inc/compatibility-largo.php
@@ -4,31 +4,40 @@
  *
  * @link https://github.com/INN/Largo
  * @since 0.2
+ * @package 
  */
 
 /**
  * Use partials/content-rounduplink.php for the rounduplink archive LMP
  *
+ * @param String   $partial    The largo partial to use for the rounduplink post type.
+ * @param WP_Query $post_query The WP_Query being used for Load More Posts.
+ * @return String
  */
-function lr_lmp_choose_partial($partial, $post_query) {
-	if ( is_object($post_query) && property_exists( $post_query, 'query_vars')) {
+function lr_lmp_choose_partial( $partial, $post_query ) {
+	if ( is_object( $post_query ) && property_exists( $post_query, 'query_vars' ) ) {
 		$post_query = $post_query->query_vars;
 	}
 
-	if ( isset($post_query['post_type']) && $post_query['post_type'] == 'rounduplink' ) {
+	if ( isset( $post_query['post_type'] ) && 'rounduplink' === $post_query['post_type'] ) {
 		$partial = 'rounduplink';
 	}
 	return $partial;
 }
-add_filter( 'largo_lmp_template_partial', 'lr_lmp_choose_partial', 10, 2);
+add_filter( 'largo_lmp_template_partial', 'lr_lmp_choose_partial', 10, 2 );
 
 /**
  * Use partials/content-rounduplink.php for the search LMP.
+ *
+ * @param  String $partial   The template partial to use for link roundups.
+ * @param  String $post_type The post type.
+ * @param  Mixed  $context   The context of this partial's use.
+ * @return String $partial   The template partial to use.
  */
-function lr_largo_partial_by_post_type($partial, $post_type, $context) {
-	if ( $post_type == 'rounduplink' ) {
+function lr_largo_partial_by_post_type( $partial, $post_type, $context ) {
+	if ( 'rounduplink' === $post_type ) {
 		$partial = 'rounduplink';
 	}
 	return $partial;
 }
-add_filter('largo_partial_by_post_type', 'lr_largo_partial_by_post_type', 10, 3);
+add_filter( 'largo_partial_by_post_type', 'lr_largo_partial_by_post_type', 10, 3 );

--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -12,18 +12,19 @@ function redirect_argolinks_requests() {
 	// @see http://webcheatsheet.com/php/get_current_page_url.php
 	$pageURL = 'http';
 
-	if ( isset($_SERVER['HTTPS'] ) )
+	if ( isset( $_SERVER['HTTPS'] ) ) {
 		$pageURL .= 's';
+	}
 
 	$pageURL .= '://';
 
-	if ( isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' ) {
+	if ( isset( $_SERVER['SERVER_PORT'] ) && $_SERVER['SERVER_PORT'] != '80' ) {
 		$pageURL .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI'];
 	} else {
 		$pageURL .= $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
 	}
 
-	if( strpos( $pageURL, 'post_type=argolinks' ) ) {
+	if ( strpos( $pageURL, 'post_type=argolinks' ) ) {
 		$newURL = str_replace( 'post_type=argolinks', 'post_type=rounduplink', $pageURL );
 
 		// Header redirect

--- a/inc/link-roundups/class-link-roundups-editor.php
+++ b/inc/link-roundups/class-link-roundups-editor.php
@@ -82,7 +82,7 @@ class LinkRoundupsEditor {
 	 * @since 0.3
 	 */
 	public static function add_tinymce_plugin( $plugins ) {
-		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+		$suffix                          = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		$plugins['link_roundups_editor'] = LROUNDUPS_DIR_URI . '/js/lroundups-editor' . $suffix . '.js';
 		return $plugins;
 	}
@@ -106,11 +106,14 @@ class LinkRoundupsEditor {
 			LROUNDUPS_DIR_URI . '/js/vendor/jquery-serialize-object/dist/jquery.serialize-object.min.js'
 		);
 
-		add_action( 'admin_enqueue_scripts', function() {
-			wp_enqueue_script( 'lroundups-typeahead' );
-			wp_enqueue_script( 'lroundups-jquery-serialize-object' );
-			wp_enqueue_style( 'lroundups-editor' );
-		});
+		add_action(
+			'admin_enqueue_scripts',
+			function() {
+				wp_enqueue_script( 'lroundups-typeahead' );
+				wp_enqueue_script( 'lroundups-jquery-serialize-object' );
+				wp_enqueue_style( 'lroundups-editor' );
+			}
+		);
 	}
 
 	/**
@@ -121,13 +124,13 @@ class LinkRoundupsEditor {
 	public static function add_modal_template() {
 		$screen = get_current_screen();
 		if ( $screen->base == 'post' && $screen->post_type == 'roundup' ) {
-			LinkRoundupsEditor::modal_underscore_template();
+			self::modal_underscore_template();
 
-	?>
+			?>
 		<script type="text/javascript">
-			var LR = <?php echo json_encode( LinkRoundupsEditor::json_obj() ); ?>;
+			var LR = <?php echo json_encode( self::json_obj() ); ?>;
 		</script>
-	<?php
+			<?php
 		}
 	}
 
@@ -136,7 +139,8 @@ class LinkRoundupsEditor {
 	 *
 	 * @since 0.2
 	 */
-	public static function modal_underscore_template() { ?>
+	public static function modal_underscore_template() {
+		?>
 		<script type="text/template" id="lroundups-modal-tmpl">
 			<div class="lroundups-modal-header">
 				<div class="lroundups-modal-close"><span class="close">&#10005;</span></div>
@@ -239,7 +243,8 @@ class LinkRoundupsEditor {
 				<% } %>
 			</p>
 		</script>
-	<?php }
+		<?php
+	}
 
 	/**
 	 * Builds a LR object with common attributes used throughout the plugin's javascript files.
@@ -251,12 +256,15 @@ class LinkRoundupsEditor {
 
 		$roundup_posts = self::roundup_block_posts_query();
 
-		return array_merge( array(
-			'post_id' => $post->ID,
-			'ajax_nonce' => wp_create_nonce( 'lroundups_ajax_nonce' ),
-			'plugin_url' => LROUNDUPS_DIR_URI,
-			'roundup_posts' => $roundup_posts
-		), $add );
+		return array_merge(
+			array(
+				'post_id'       => $post->ID,
+				'ajax_nonce'    => wp_create_nonce( 'lroundups_ajax_nonce' ),
+				'plugin_url'    => LROUNDUPS_DIR_URI,
+				'roundup_posts' => $roundup_posts,
+			),
+			$add
+		);
 	}
 
 	/*
@@ -265,23 +273,28 @@ class LinkRoundupsEditor {
 	 * @since 0.3.2
 	 */
 	public static function roundup_update_post() {
-		check_ajax_referer('lroundups_ajax_nonce', 'security');
+		check_ajax_referer( 'lroundups_ajax_nonce', 'security' );
 
 		if ( ! current_user_can( apply_filters( 'link_roundups_minimum_capability', 'edit_posts' ) ) ) {
 			wp_die();
 		}
 
 		if ( isset( $_POST['post'] ) ) {
-			$post_data = json_decode(stripslashes($_POST['post']), true);
+			$post_data = json_decode( stripslashes( $_POST['post'] ), true );
 
 			$custom_fields = $post_data['custom_fields'];
-			unset($post_data['custom_fields']);
+			unset( $post_data['custom_fields'] );
 
 			$post_id = wp_update_post( $post_data );
 
 			if ( is_wp_error( $post_id ) ) {
 				$errors = $post_id->get_error_messages();
-				print json_encode( array( 'success' => false, 'message' => $errors ) );
+				print json_encode(
+					array(
+						'success' => false,
+						'message' => $errors,
+					)
+				);
 				wp_die();
 			}
 
@@ -295,19 +308,27 @@ class LinkRoundupsEditor {
 
 	public static function roundup_block_posts_query() {
 		// Default arguments
-		$args = apply_filters('link_roundups_roundup_block_post_query', array(
-			'post_type' => 'rounduplink',
-			'orderby' => 'date',
-			'order' => 'desc',
-			'posts_per_page' => 10,
-			'date_query' => array(
-				'year' => date( 'Y' ),
-				'monthnum' => date( 'm' ),
+		$args  = apply_filters(
+			'link_roundups_roundup_block_post_query',
+			array(
+				'post_type'      => 'rounduplink',
+				'orderby'        => 'date',
+				'order'          => 'desc',
+				'posts_per_page' => 10,
+				'date_query'     => array(
+					'year'     => date( 'Y' ),
+					'monthnum' => date( 'm' ),
+				),
 			)
-		));
-		$query = new WP_Query($args);
+		);
+		$query = new WP_Query( $args );
 		$posts = $query->get_posts();
-		$ids = array_map(function($x) { return $x->ID; }, $posts);
+		$ids   = array_map(
+			function( $x ) {
+					return $x->ID;
+			},
+			$posts
+		);
 
 		// If any of the post ids in the shortcode attribute don't show up
 		// in the queried posts, try finding them separately
@@ -321,7 +342,7 @@ class LinkRoundupsEditor {
 			preg_match_all( '/\[roundup_block.*ids\=\"([0-9,]+)\".*\]/', $post->post_content, $matches );
 			if ( ! empty( $matches ) ) {
 				foreach ( $matches[1] as $group ) {
-					$foundIds = split(',', $group);
+					$foundIds = split( ',', $group );
 					foreach ( $foundIds as $id ) {
 						array_push( $exisitingIds, $id );
 					}
@@ -336,7 +357,7 @@ class LinkRoundupsEditor {
 			}
 		}
 
-		foreach ($exisitingIds as $exisitingId) {
+		foreach ( $exisitingIds as $exisitingId ) {
 			if ( ! in_array( $exisitingId, $ids ) ) {
 				$p = get_post( $exisitingId );
 				if ( ! empty( $p ) && ! is_wp_error( $p ) ) {
@@ -345,12 +366,17 @@ class LinkRoundupsEditor {
 			}
 		}
 
-		usort( $posts, function($a, $b) { return strcmp( $b->post_date, $a->post_date ); } );
+		usort(
+			$posts,
+			function( $a, $b ) {
+				return strcmp( $b->post_date, $a->post_date );
+			}
+		);
 
 		foreach ( $posts as $idx => $post ) {
-			$post->order = $idx;
-			$post->custom_fields = get_post_custom( $post->ID );
-			$post->source = get_bloginfo( 'name' );
+			$post->order          = $idx;
+			$post->custom_fields  = get_post_custom( $post->ID );
+			$post->source         = get_bloginfo( 'name' );
 			$post->post_permalink = get_permalink( $post->ID );
 		}
 		return $posts;
@@ -362,18 +388,18 @@ class LinkRoundupsEditor {
 	 * @since 0.3.2
 	 */
 	public static function roundup_block_posts() {
-		check_ajax_referer('lroundups_ajax_nonce', 'security');
+		check_ajax_referer( 'lroundups_ajax_nonce', 'security' );
 		$posts = self::roundup_block_posts_query();
-		print json_encode($posts);
+		print json_encode( $posts );
 		wp_die();
 	}
 
 	/**
 	 * Apply information from a Link Roundup post to a WordPress MailChimp Tools email via the appropriate filter
 	 *
-	 * @param Array $campaign_params An array of request body parameters, as described in the "put" section of https://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/content/#%20
+	 * @param Array   $campaign_params An array of request body parameters, as described in the "put" section of https://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/content/#%20
 	 * @param WP_Post $post The post that is being turned into a MailChimp Campaign
-	 * @param int $id The campaign ID
+	 * @param int     $id The campaign ID
 	 * @return Array $params
 	 *
 	 * @link the commit that implemented this filter: https://github.com/INN/wordpress-mailchimp-tools/commit/4e768f7661a2fe8fc2785140e8313280eb230c3f
@@ -395,9 +421,9 @@ class LinkRoundupsEditor {
 		if ( ! isset( $campaign_params['template']['sections'] ) ) {
 			$campaign_params['template']['sections'] = array();
 		}
-		$campaign_params['template']['sections']['rounduplinks'] = apply_filters( 'the_content', $post->post_content );
-		$campaign_params['template']['sections']['rounduptitle'] = $post->post_title;
-		$campaign_params['template']['sections']['roundupdate'] = get_the_date( '', $post->ID );
+		$campaign_params['template']['sections']['rounduplinks']     = apply_filters( 'the_content', $post->post_content );
+		$campaign_params['template']['sections']['rounduptitle']     = $post->post_title;
+		$campaign_params['template']['sections']['roundupdate']      = get_the_date( '', $post->ID );
 		$campaign_params['template']['sections']['rounduppermalink'] = get_post_permalink( $post->ID );
 
 		$author = get_user_by( 'id', $post->post_author );

--- a/inc/link-roundups/class-link-roundups-widget.php
+++ b/inc/link-roundups/class-link-roundups-widget.php
@@ -7,35 +7,39 @@ class link_roundups_widget extends WP_Widget {
 
 	function __construct() {
 		$widget_ops = array(
-			'classname' 	=> 'link-roundups',
-			'description' 	=> 'Show your most recent link roundups in the sidebar', 'link-roundups'
+			'classname'   => 'link-roundups',
+			'description' => 'Show your most recent link roundups in the sidebar',
+			'link-roundups',
 		);
-		parent::__construct(  'link_roundups_widget', __( 'Link Roundups Widget', 'link-roundups' ), $widget_ops );
+		parent::__construct( 'link_roundups_widget', __( 'Link Roundups Widget', 'link-roundups' ), $widget_ops );
 	}
 
 	function widget( $args, $instance ) {
 		// make it possible for the widget title to be a link
-		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Recent Link Roundups' , 'link-roundups') : $instance['title'], $instance, $this->id_base);
+		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? __( 'Recent Link Roundups', 'link-roundups' ) : $instance['title'], $instance, $this->id_base );
 
 		echo $args['before_widget'];
 
-		if ( !empty( $title ) ) {
+		if ( ! empty( $title ) ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
-		$query_args = array (
-			'post__not_in' 	=> get_option( 'sticky_posts' ),
-			'posts_per_page' 	=> $instance['num_posts'],
-			'post_type' 	=> 'post',
-			'post_status'	=> 'publish'
+		$query_args = array(
+			'post__not_in'   => get_option( 'sticky_posts' ),
+			'posts_per_page' => $instance['num_posts'],
+			'post_type'      => 'post',
+			'post_status'    => 'publish',
 		);
 
-		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
+		if ( $instance['cat'] != '' ) {
+			$query_args['cat'] = $instance['cat'];
+		}
 
 		$my_query = new WP_Query( $query_args );
-			if ( $my_query->have_posts() ) {
-				while ( $my_query->have_posts() ) : $my_query->the_post();
-					$custom = get_post_custom( $post->ID ); ?>
+		if ( $my_query->have_posts() ) {
+			while ( $my_query->have_posts() ) :
+				$my_query->the_post();
+				$custom = get_post_custom( $post->ID ); ?>
 					<div class="post-lead clearfix">
 						<?php
 						// the date
@@ -48,39 +52,41 @@ class link_roundups_widget extends WP_Widget {
 						?>
 
 					</div> <!-- /.post-lead -->
-			<?php
+				<?php
 				endwhile;
-			} else {
-				_e( '<p class="error"><strong>You don\'t have any recent links or the Link Roundups plugin is not active.</strong></p>', 'link-roundups' );
-			} // end recent links
+		} else {
+			_e( '<p class="error"><strong>You don\'t have any recent links or the Link Roundups plugin is not active.</strong></p>', 'link-roundups' );
+		} // end recent links
 
-		if ( $instance['linkurl'] !='' ) { ?>
+		if ( $instance['linkurl'] != '' ) {
+			?>
 			<p class="morelink"><a href="<?php echo $instance['linkurl']; ?>"><?php echo $instance['linktext']; ?></a></p>
-		<?php }
+			<?php
+		}
 
 		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {
-		$instance = $old_instance;
-		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance              = $old_instance;
+		$instance['title']     = strip_tags( $new_instance['title'] );
 		$instance['num_posts'] = intval( strip_tags( $new_instance['num_posts'] ) );
-		$instance['linktext'] = $new_instance['linktext'];
-		$instance['linkurl'] = esc_url_raw( $new_instance['linkurl'] );
-		$instance['cat'] = intval( $new_instance['cat'] );
+		$instance['linktext']  = $new_instance['linktext'];
+		$instance['linkurl']   = esc_url_raw( $new_instance['linkurl'] );
+		$instance['cat']       = intval( $new_instance['cat'] );
 		return $instance;
 	}
 
 	function form( $instance ) {
 		$defaults = array(
-			'title' 		=> 'Recent Link Roundups',
-			'num_posts' 	=> 1,
-			'linktext' 		=> '',
-			'linkurl' 		=> '',
-			'cat' 			=> 0,
+			'title'     => 'Recent Link Roundups',
+			'num_posts' => 1,
+			'linktext'  => '',
+			'linkurl'   => '',
+			'cat'       => 0,
 		);
 
-		$instance = wp_parse_args( ( array ) $instance, $defaults );
+		$instance = wp_parse_args( (array) $instance, $defaults );
 		?>
 
 		<p>
@@ -95,7 +101,18 @@ class link_roundups_widget extends WP_Widget {
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'cat' ); ?>"><?php _e( 'Limit to category: ', 'link-roundups' ); ?>
-			<?php wp_dropdown_categories( array( 'name' => $this->get_field_name( 'cat' ), 'show_option_all' => __( 'None (all categories)', 'link-roundups' ), 'hide_empty' => 0, 'hierarchical' => 1, 'selected' => $instance['cat'] ) ); ?></label>
+			<?php
+			wp_dropdown_categories(
+				array(
+					'name'            => $this->get_field_name( 'cat' ),
+					'show_option_all' => __( 'None (all categories)', 'link-roundups' ),
+					'hide_empty'      => 0,
+					'hierarchical'    => 1,
+					'selected'        => $instance['cat'],
+				)
+			);
+			?>
+			</label>
 		</p>
 
 		<p><strong><?php _e( 'More Link', 'link-roundups' ); ?></strong><br /><small><?php _e( 'If you would like to add a more link at the bottom of the widget, add the link text and url here.', 'link-roundups' ); ?></small></p>
@@ -109,6 +126,6 @@ class link_roundups_widget extends WP_Widget {
 			<input class="widefat" id="<?php echo $this->get_field_id( 'linkurl' ); ?>" name="<?php echo $this->get_field_name( 'linkurl' ); ?>" type="url" value="<?php echo $instance['linkurl']; ?>" />
 		</p>
 
-	<?php
+		<?php
 	}
 }

--- a/inc/link-roundups/class-link-roundups.php
+++ b/inc/link-roundups/class-link-roundups.php
@@ -15,10 +15,10 @@ class LinkRoundups {
 	public static function init() {
 
 		// Register the custom post type of roundup
-		add_action('init', array( __CLASS__, 'register_post_type' ) );
+		add_action( 'init', array( __CLASS__, 'register_post_type' ) );
 
 		// Add the Link Roundups Options sub menu
-		add_action( 'admin_menu', array( __CLASS__, 'add_lroundups_options_page') );
+		add_action( 'admin_menu', array( __CLASS__, 'add_lroundups_options_page' ) );
 
 		// Add our custom post fields for our custom post type
 		add_action( 'admin_init', array( __CLASS__, 'add_custom_post_fields' ) );
@@ -40,8 +40,12 @@ class LinkRoundups {
 	// Merge the post_type query var if there is already a custom post type being pulled in otherwise do post & linkroundups
 	public static function lr_get_posts( &$query ) {
 		// bail out early if suppress filters is set to true
-		if ( $query->get( 'suppress_filters' ) ) return;
-		if ( is_admin() ) return;
+		if ( $query->get( 'suppress_filters' ) ) {
+			return;
+		}
+		if ( is_admin() ) {
+			return;
+		}
 
 		// Add roundup to the post type in the query if it is not already in it.
 		if ( $query->is_home() || $query->is_tag() || $query->is_category() || $query->is_author() ) {
@@ -50,14 +54,14 @@ class LinkRoundups {
 					// There is an array of post types and roundup is not in it
 					$query->set( 'post_type', array_merge( array( 'roundup' ), $query->query_vars['post_type'] ) );
 				}
-			} elseif ( isset( $query->query_vars['post_type'] ) && !is_array( $query->query_vars['post_type'] ) ) {
+			} elseif ( isset( $query->query_vars['post_type'] ) && ! is_array( $query->query_vars['post_type'] ) ) {
 				if ( $query->query_vars['post_type'] !== 'roundup' ) {
 					// There is a single post type, so we shall add it to an array
 					$query->set( 'post_type', array( 'roundup', $query->query_vars['post_type'] ) );
 				}
 			} else {
 				// Post type is not set, so it shall be post and roundup
-				$query->set( 'post_type', array( 'post','roundup' ) );
+				$query->set( 'post_type', array( 'post', 'roundup' ) );
 			}
 		}
 	}
@@ -70,51 +74,59 @@ class LinkRoundups {
 	 */
 	public static function register_post_type() {
 		$singular_opt = get_option( 'lroundups_custom_name_singular' );
-		$plural_opt = get_option( 'lroundups_custom_name_plural' );
-		$slug_opt = get_option( 'lroundups_custom_url' );
+		$plural_opt   = get_option( 'lroundups_custom_name_plural' );
+		$slug_opt     = get_option( 'lroundups_custom_url' );
 
-		if( !empty( $singular_opt ) ) {
+		if ( ! empty( $singular_opt ) ) {
 			$singular = $singular_opt;
-		}
-		else {
+		} else {
 			$singular = 'Link Roundup';
 		}
 
-		if( !empty( $plural_opt ) ) {
+		if ( ! empty( $plural_opt ) ) {
 			$plural = $plural_opt;
-		}
-		else {
+		} else {
 			$plural = 'Link Roundups';
 		}
 
 		$roundup_options = array(
-			'labels' 		=> array(
-				'name' 			=> $plural,
-				'singular_name' => $singular,
-				'add_new' 		=> 'Add '. $singular,
-				'add_new_item' 	=> 'Add New '. $singular,
-				'edit' 			=> 'Edit',
-				'edit_item'		=> 'Edit ' . $singular,
-				'view' 			=> 'View',
-				'view_item' 	=> 'View ' . $singular,
-				'search_items' 	=> 'Search ' . $plural,
-				'not_found' 	=> 'No ' . $plural . ' found',
+			'labels'        => array(
+				'name'               => $plural,
+				'singular_name'      => $singular,
+				'add_new'            => 'Add ' . $singular,
+				'add_new_item'       => 'Add New ' . $singular,
+				'edit'               => 'Edit',
+				'edit_item'          => 'Edit ' . $singular,
+				'view'               => 'View',
+				'view_item'          => 'View ' . $singular,
+				'search_items'       => 'Search ' . $plural,
+				'not_found'          => 'No ' . $plural . ' found',
 				'not_found_in_trash' => 'No ' . $plural . ' found in Trash',
 			),
-			'description' 	=> $plural,
-			'supports' 		=> array(
-				'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks', 'custom-fields',
-				'comments', 'revisions', 'page-attributes', 'post-formats'
+			'description'   => $plural,
+			'supports'      => array(
+				'title',
+				'editor',
+				'author',
+				'thumbnail',
+				'excerpt',
+				'trackbacks',
+				'custom-fields',
+				'comments',
+				'revisions',
+				'page-attributes',
+				'post-formats',
 			),
-			'public' 		=> true,
+			'public'        => true,
 			'menu_position' => 7,
-			'menu_icon' 	=> 'dashicons-list-view',
-			'taxonomies' 	=> apply_filters( 'roundup_taxonomies', array( 'category','post_tag' ) ),
-			'has_archive' 	=> true,
+			'menu_icon'     => 'dashicons-list-view',
+			'taxonomies'    => apply_filters( 'roundup_taxonomies', array( 'category', 'post_tag' ) ),
+			'has_archive'   => true,
 		);
 
-		if ( $slug_opt != '' )
+		if ( $slug_opt != '' ) {
 			$roundup_options['rewrite'] = array( 'slug' => $slug_opt );
+		}
 
 		register_post_type( 'roundup', $roundup_options );
 		if ( function_exists( 'mailchimp_tools_register_for_post_type' ) ) {
@@ -124,15 +136,15 @@ class LinkRoundups {
 
 	/*Add our css stylesheet into tinymce*/
 	public static function plugin_mce_css( $mce_css ) {
-		if ( !empty( $mce_css ) ) {
+		if ( ! empty( $mce_css ) ) {
 			$mce_css .= ',';
 		} else {
 			$mce_css = '';
 		}
 		// check if styles have been removed
-		$remove_styles = get_option('lroundups_dequeue_styles');
-		if (empty($remove_styles)) {
-			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+		$remove_styles = get_option( 'lroundups_dequeue_styles' );
+		if ( empty( $remove_styles ) ) {
+			$suffix   = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 			$mce_css .= plugins_url( 'css/lroundups' . $suffix . '.css', LROUNDUPS_PLUGIN_FILE );
 			return $mce_css;
 		}
@@ -141,10 +153,10 @@ class LinkRoundups {
 	/*Add our css stylesheet into the header*/
 	public static function add_styles() {
 		// check if styles should be removed
-		$remove_styles = get_option('lroundups_dequeue_styles');
-		if (empty($remove_styles)) {
-			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )  ? '' : '.min';
-			$css = plugins_url(  'css/lroundups' . $suffix . '.css', LROUNDUPS_PLUGIN_FILE);
+		$remove_styles = get_option( 'lroundups_dequeue_styles' );
+		if ( empty( $remove_styles ) ) {
+			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+			$css    = plugins_url( 'css/lroundups' . $suffix . '.css', LROUNDUPS_PLUGIN_FILE );
 			wp_enqueue_style( 'link-roundups', $css, array(), 1 );
 		}
 	}
@@ -157,8 +169,12 @@ class LinkRoundups {
 	 */
 	public static function add_custom_post_fields() {
 		add_meta_box(
-			'link_roundups_roundup', 'Recent Saved Links',
-			array( __CLASS__, 'display_custom_fields' ), 'roundup', 'advanced', 'high'
+			'link_roundups_roundup',
+			'Recent Saved Links',
+			array( __CLASS__, 'display_custom_fields' ),
+			'roundup',
+			'advanced',
+			'high'
 		);
 	}
 
@@ -197,11 +213,11 @@ class LinkRoundups {
 		if ( isset( $_POST ) ) {
 			// error_log(var_export( $_POST['mailchimp'], true));
 		}
-		if ( isset( $_POST['lr_url'] ) ){
-			update_post_meta( ( isset( $_POST['post_id'] ) ? $_POST['post_ID'] : $post_id ), 'lr_url', $_POST["lr_url"] );
+		if ( isset( $_POST['lr_url'] ) ) {
+			update_post_meta( ( isset( $_POST['post_id'] ) ? $_POST['post_ID'] : $post_id ), 'lr_url', $_POST['lr_url'] );
 		}
 		if ( isset( $_POST['lr_desc'] ) ) {
-			update_post_meta( ( isset($_POST['post_id'] ) ? $_POST['post_ID'] : $post_id ), 'lr_desc', $_POST['lr_desc'] );
+			update_post_meta( ( isset( $_POST['post_id'] ) ? $_POST['post_ID'] : $post_id ), 'lr_desc', $_POST['lr_desc'] );
 		}
 	}
 
@@ -212,12 +228,12 @@ class LinkRoundups {
 	 */
 	public static function add_lroundups_options_page() {
 		add_submenu_page(
-			'edit.php?post_type=roundup', 	// $parent_slug
-			'Options', 						// $page_title
-			'Options', 						// $menu_title
+			'edit.php?post_type=roundup',   // $parent_slug
+			'Options',                      // $page_title
+			'Options',                      // $menu_title
 			apply_filters( 'link_roundups_minimum_capability', 'edit_posts' ), // $capability
-			'link-roundups-options',  	    // $menu_slug
-			array( __CLASS__, 'build_lroundups_options_page' ) 	// $function
+			'link-roundups-options',        // $menu_slug
+			array( __CLASS__, 'build_lroundups_options_page' )  // $function
 		);
 
 		// call register settings function
@@ -235,12 +251,12 @@ class LinkRoundups {
 
 	public static function build_lroundups_options_page() {
 		// get the custom url
-		$defined_url = get_option('lroundups_custom_url');
+		$defined_url = get_option( 'lroundups_custom_url' );
 
 		// check if settings have been updated and if there is a custom slug
 		// TODO: don't flush rewrite rules unless they've actually chanaged since
 		// the last time they were flushed.
-		if (isset($_GET['settings-updated']) && !empty($defined_url)) {
+		if ( isset( $_GET['settings-updated'] ) && ! empty( $defined_url ) ) {
 			flush_rewrite_rules();
 		}
 

--- a/inc/link-roundups/class-save-to-site-button.php
+++ b/inc/link-roundups/class-save-to-site-button.php
@@ -17,14 +17,14 @@
  *
  * @since 0.3
  */
-if ( !defined('ABSPATH') ) {
+if ( ! defined( 'ABSPATH' ) ) {
 
 	// Load WordPress
 	define( 'WP_USE_THEMES', false );
-	require_once( '../../../wp-admin/admin.php' );
+	require_once '../../../wp-admin/admin.php';
 
 	// Generate URL redirect
-	$URL = parse_url( $_SERVER['REQUEST_URI'] );
+	$URL    = parse_url( $_SERVER['REQUEST_URI'] );
 	$newURL = admin_url( 'post-new.php?' . $URL['query'] );
 
 	// Header redirect
@@ -46,7 +46,7 @@ class Save_To_Site_Button {
 	 * @since 0.3
 	 */
 	public static function init() {
-		if ( isset( $_GET[ 'u' ] ) ) {
+		if ( isset( $_GET['u'] ) ) {
 			add_action( 'load-post-new.php', array( __CLASS__, 'load' ) );
 			add_action( 'load-post.php', array( __CLASS__, 'load' ) );
 		}
@@ -71,7 +71,7 @@ class Save_To_Site_Button {
 		$shortcut_link = '';
 
 		if (
-			version_compare( get_bloginfo('version'), '4.9', '<' )
+			version_compare( get_bloginfo( 'version' ), '4.9', '<' )
 			&& function_exists( 'get_shortcut_link' )
 		) {
 			$shortcut_link = htmlspecialchars( get_shortcut_link() );
@@ -97,15 +97,17 @@ class Save_To_Site_Button {
 	/**
 	 * Sets up default values for new Saved Link.
 	 *
+	 * These values are all static properties; I think that works because this instance of this class is only valid within this page load.
+	 *
 	 * @since 0.3
 	 */
-	function load() {
-		$meta = $_POST['_meta'];
-		$links = $_POST['_links'];
-		$images = $_POST['_images'];
-		$embeds = $_POST['_embeds'];
+	public static function load() {
+		$meta   = isset( $_POST['_meta'] ) ? $_POST['_meta'] : array();
+		$links  = isset( $_POST['_links'] ) ? $_POST['_links'] : null;
+		$images = isset( $_POST['_images'] ) ? $_POST['_images'] : null;
+		$embeds = isset( $_POST['_embeds'] ) ? $_POST['_embeds'] : null;
 
-		self::$url = isset( $_GET[ 'u' ] ) ? esc_url( $_GET[ 'u' ] ) : '';
+		self::$url = isset( $_GET['u'] ) ? esc_url( $_GET['u'] ) : '';
 		self::$url = wp_kses( urldecode( self::$url ), null );
 
 		// Default title
@@ -113,34 +115,34 @@ class Save_To_Site_Button {
 		if ( ! empty( $meta['og:title'] ) ) {
 			self::$title = $meta['og:title'];
 		} else {
-			self::$title = isset( $_POST[ 't' ] ) ? trim( strip_tags( html_entity_decode( stripslashes( $_POST[ 't' ] ), ENT_QUOTES ) ) ) : '';
+			self::$title = isset( $_POST['t'] ) ? trim( strip_tags( html_entity_decode( stripslashes( $_POST['t'] ), ENT_QUOTES ) ) ) : '';
 		}
 
 		$selection = '';
-		if ( ! empty( $_POST[ 's' ] ) ) {
-			$selection = str_replace( '&apos;', "'", stripslashes( $_POST[ 's' ] ) );
+		if ( ! empty( $_POST['s'] ) ) {
+			$selection = str_replace( '&apos;', "'", stripslashes( $_POST['s'] ) );
 			$selection = '<blockquote>' . trim( htmlspecialchars( html_entity_decode( $selection, ENT_QUOTES ) ) ) . '</blockquote>';
 		}
 
 		// Default description
 		self::$description = '';
-		if ( !empty( $selection ) ) {
+		if ( ! empty( $selection ) ) {
 			self::$description = $selection;
-		} else if( !empty($meta['og:description']) ) {
+		} elseif ( ! empty( $meta['og:description'] ) ) {
 			self::$description = $meta['og:description'];
 		}
 
 		// Default source
 		self::$source = '';
-		if( !empty($meta['og:site_name']) ) {
+		if ( ! empty( $meta['og:site_name'] ) ) {
 			self::$source = $meta['og:site_name'];
-		} else if( self::$url ) {
-			$url = parse_url(self::$url);
+		} elseif ( self::$url ) {
+			$url          = parse_url( self::$url );
 			self::$source = $url['host'];
 		}
 
 		self::$imgUrl = '';
-		if( ! empty( $meta['og:image'] ) ) {
+		if ( ! empty( $meta['og:image'] ) ) {
 			self::$imgUrl = $meta['og:image'];
 		}
 
@@ -148,7 +150,6 @@ class Save_To_Site_Button {
 		 * Default Link Roundups Values for Custom Meta
 		 *
 		 * Register default title, link URL, link description and link source.
-		 * Used within popup so hides the Admin Bar
 		 *
 		 * @since x.x.x
 		 *
@@ -162,9 +163,10 @@ class Save_To_Site_Button {
 		 * @param type  $var Description.
 		 */
 		add_filter( 'default_title', array( __CLASS__, 'default_title' ) );
-		add_filter( 'default_link_url', array( __CLASS__, 'default_link' ));
+		add_filter( 'default_link_url', array( __CLASS__, 'default_link' ) );
 		add_filter( 'default_link_description', array( __CLASS__, 'default_description' ) );
 		add_filter( 'default_link_source', array( __CLASS__, 'default_source' ) );
+		// attempt to hide the Toolbar in the backend, probably fails in newer WordPress versions.
 		add_filter( 'show_admin_bar', '__return_false' );
 	}
 

--- a/inc/saved-links/class-saved-links-list-table.php
+++ b/inc/saved-links/class-saved-links-list-table.php
@@ -15,7 +15,7 @@
  * @see inc/saved-links/class-wp-list-table-clone.php
  * @since 0.3.2
  */
-require_once( __DIR__ . '/class-wp-list-table-clone.php' );
+require_once __DIR__ . '/class-wp-list-table-clone.php';
 
 
 /**
@@ -33,10 +33,12 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	 * @since 0.3.2
 	 */
 	function __construct() {
-		parent::__construct( array(
-			'singular' => 'lroundups-link',
-			'plural' => 'lroundups-links',
-		));
+		parent::__construct(
+			array(
+				'singular' => 'lroundups-link',
+				'plural'   => 'lroundups-links',
+			)
+		);
 	}
 
 	/**
@@ -66,32 +68,32 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 				<form method='get' id='filter_links_container'>
 					<label for='link_date'><b><?php _e( 'Date Range:', 'link-roundups' ); ?></b></label>
 					<select name='link_date'>
-						<option value='today'      <?php selected( $request['link_date'], 'today'      ); ?>><?php _e( 'Today',' link-roundups' ); ?></option>
-						<option value='this_week'  <?php selected( $request['link_date'], 'this_week'  ); ?>><?php _e( 'This Week',' link-roundups' ); ?></option>
-						<option value='this_month' <?php selected( $request['link_date'], 'this_month' ); ?>><?php _e( 'This Month',' link-roundups' ); ?></option>
-						<option value='this_year'  <?php selected( $request['link_date'], 'this_year'  ); ?>><?php _e( 'This Year',' link-roundups' ); ?></option>
-						<option value='show_all'   <?php selected( $request['link_date'], 'show_all'   ); ?>><?php _e( 'Show All',' link-roundups' ); ?></option>
+						<option value='today'      <?php selected( $request['link_date'], 'today' ); ?>><?php _e( 'Today', ' link-roundups' ); ?></option>
+						<option value='this_week'  <?php selected( $request['link_date'], 'this_week' ); ?>><?php _e( 'This Week', ' link-roundups' ); ?></option>
+						<option value='this_month' <?php selected( $request['link_date'], 'this_month' ); ?>><?php _e( 'This Month', ' link-roundups' ); ?></option>
+						<option value='this_year'  <?php selected( $request['link_date'], 'this_year' ); ?>><?php _e( 'This Year', ' link-roundups' ); ?></option>
+						<option value='show_all'   <?php selected( $request['link_date'], 'show_all' ); ?>><?php _e( 'Show All', ' link-roundups' ); ?></option>
 					</select>
-					<?php if( isset( $request['orderby'] ) ) : ?>
+					<?php if ( isset( $request['orderby'] ) ) : ?>
 						<input type='hidden' name='orderby' value='<?php echo esc_attr( $request['orderby'] ); ?>'/>
-					<?php endif;?>
-					<?php if( isset($request['order'] ) ) : ?>
+					<?php endif; ?>
+					<?php if ( isset( $request['order'] ) ) : ?>
 						<input type='hidden' name='order' value='<?php echo esc_attr( $request['order'] ); ?>'/>
-					<?php endif;?>
+					<?php endif; ?>
 					<input id="filter_links" class='button' type='submit' value='Filter'/><span class="spinner"></span>
 				</form>
 			</div>
-		<?php
+			<?php
 		}
 
 		if ( $which === 'bottom' ) {
-		?>
+			?>
 			<div style='float:left;'>
 				<a class="button" href="<?php echo esc_attr( admin_url( 'post-new.php?post_type=rounduplink' ) ); ?>">
 					<?php echo strip_tags( __( 'Create new Saved Link', 'link-roundups' ) ); ?>
 				</a>
 			</div>
-		<?php
+			<?php
 		}
 
 	}
@@ -104,11 +106,11 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	function get_columns() {
 		return $columns = array(
 			// name => text,
-			'cb' => 'cb', // single_row_columns will turn this into a checkbox.
-			'title' => 'Title',
+			'cb'          => 'cb', // single_row_columns will turn this into a checkbox.
+			'title'       => 'Title',
 			'post_author' => 'Author',
-			'tags' => 'Tags',
-			'date' => 'Date'
+			'tags'        => 'Tags',
+			'date'        => 'Date',
 		);
 	}
 
@@ -119,10 +121,10 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	 */
 	function get_sortable_columns() {
 		return $columns = array(
-			'title' => 'post_title',
+			'title'       => 'post_title',
 			'post_author' => 'post_author',
-			'tags' => 'tags_input',
-			'date' => 'post_date'
+			'tags'        => 'tags_input',
+			'date'        => 'post_date',
 		);
 	}
 
@@ -141,7 +143,7 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 		// Number of posts per page, from $_REQUEST
 		$posts_per_page = ( isset( $_REQUEST['posts_per_page'] ) ? $_REQUEST['posts_per_page'] : 15 );
 		// Which page of results to get, from $_REQUEST
-		$page = ( isset( $_REQUEST['lroundups_page'] ) ? $_REQUEST['lroundups_page'] : 1);
+		$page = ( isset( $_REQUEST['lroundups_page'] ) ? $_REQUEST['lroundups_page'] : 1 );
 
 		/*
 		 * Date
@@ -150,35 +152,35 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 		// Define the default date query
 		// This should match the vale set as default in $this->bulk_actions()
 		$default_date = array(
-			'year' => date( 'Y' ),
+			'year'     => date( 'Y' ),
 			'monthnum' => date( 'm' ),
 		);
 
 		// Turn the filter date button's response into a meaningful WP_Query date argument
-		if ( isset($_REQUEST['link_date'] ) ) {
-			switch ($_REQUEST['link_date']) {
+		if ( isset( $_REQUEST['link_date'] ) ) {
+			switch ( $_REQUEST['link_date'] ) {
 				case 'today':
 					$default_date = array(
-						'year' => date( 'Y' ),
+						'year'     => date( 'Y' ),
 						'monthnum' => date( 'm' ),
-						'day' => date( 'd' )
+						'day'      => date( 'd' ),
 					);
 					break;
 				case 'this_week':
 					$default_date = array(
 						'year' => date( 'Y' ),
-						'w' => date( 'W' )
+						'w'    => date( 'W' ),
 					);
 					break;
 				case 'this_month':
 					$default_date = array(
-						'year' => date( 'Y' ),
-						'monthnum' => date( 'm' )
+						'year'     => date( 'Y' ),
+						'monthnum' => date( 'm' ),
 					);
 					break;
 				case 'this_year':
 					$default_date = array(
-						'year' => date( 'Y' )
+						'year' => date( 'Y' ),
 					);
 					break;
 				case 'show_all':
@@ -188,10 +190,10 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 
 		// Generic arguments
 		$args = array(
-			'post_type' 	=> 'rounduplink',
-			'orderby' 		=> ( isset($_REQUEST['orderby'] ) ? $_REQUEST['orderby'] : 'date' ),
-			'order' 		=> ( isset($_REQUEST['order'] ) ? $_REQUEST['order'] : 'desc' ),
-			'posts_per_page' => -1
+			'post_type'      => 'rounduplink',
+			'orderby'        => ( isset( $_REQUEST['orderby'] ) ? $_REQUEST['orderby'] : 'date' ),
+			'order'          => ( isset( $_REQUEST['order'] ) ? $_REQUEST['order'] : 'desc' ),
+			'posts_per_page' => -1,
 		);
 
 		// Join the date query with the generic args.
@@ -201,26 +203,29 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 		$_wp_column_headers;
 
 		$the_posts_count_query = new WP_Query( $args );
-		$total_post_count = $the_posts_count_query->post_count;
-		unset($the_posts_count_query); // to save memory
+		$total_post_count      = $the_posts_count_query->post_count;
+		unset( $the_posts_count_query ); // to save memory
 
 		// Set the pagination links automagically
-		$this->set_pagination_args(array(
-			'total_items' => $total_post_count,
-			'total_pages' => ceil($total_post_count/$posts_per_page),
-			'per_page' => $posts_per_page,
-		));
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_post_count,
+				'total_pages' => ceil( $total_post_count / $posts_per_page ),
+				'per_page'    => $posts_per_page,
+			)
+		);
 
 		// Set the columns
 		$columns = $this->get_columns();
 		if ( isset( $screen ) ) {
-			$_wp_column_headers[$screen->id] = $columns;
+			$_wp_column_headers[ $screen->id ] = $columns;
 		}
 
 		// Fetch the items
-		$links_query = new WP_Query($args);
+		$links_query = new WP_Query( $args );
 		$this->items = $links_query->posts;
-		/* This is where we begin to deviate from http://www.smashingmagazine.com/2011/11/native-admin-tables-wordpress/
+		/*
+		 This is where we begin to deviate from http://www.smashingmagazine.com/2011/11/native-admin-tables-wordpress/
 		 * Smash Magazine uses wpdb->get_results, and defines its own display_rows method to parse that.
 		 * WP_Query does the following instead::
 		 *   wp_query->get_posts()
@@ -237,9 +242,9 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	 * @param $post WP_Post object
 	 * @since 0.3.2
 	 */
-	function single_row($post) {
-		$post = get_post($post);
-		$classes .= "lroundups-link";
+	function single_row( $post ) {
+		$post     = get_post( $post );
+		$classes .= 'lroundups-link';
 
 		print "<tr class='$classes' data-post-id='$post->ID'>";
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
@@ -253,9 +258,9 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 				$classes .= ' hidden';
 			}
 			// Instead of using esc_attr(), we strip tags to get closer to a user-friendly string.
-			$data = 'data-colname="' . wp_strip_all_tags( $column_display_name ) . '"';
+			$data       = 'data-colname="' . wp_strip_all_tags( $column_display_name ) . '"';
 			$attributes = "class='$classes' $data";
-			switch ($column_name) {
+			switch ( $column_name ) {
 				case 'cb':
 					echo '<th scope="row" class="check-column">';
 					echo $this->column_cb( $post ); // Creates a checkbox for the $post
@@ -265,26 +270,26 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 					echo "<td $attributes>";
 					echo $post->post_title;
 					echo $this->handle_row_actions( $post, $column_name, $primary );
-					echo "</td>";
+					echo '</td>';
 					break;
 				case 'post_author':
 					echo "<td $attributes>";
-					echo the_author_meta('display_name', $post->post_author);
-					echo "</td>";
+					echo the_author_meta( 'display_name', $post->post_author );
+					echo '</td>';
 					break;
 				case 'tags':
 					echo "<td $attributes>";
-					echo get_the_term_list($post->ID, 'lr-tags', '', ', ', '');
-					echo "</td>";
+					echo get_the_term_list( $post->ID, 'lr-tags', '', ', ', '' );
+					echo '</td>';
 					break;
 				case 'date':
 					echo "<td $attributes>";
-					echo get_the_date( '', $post->ID);
-					echo "</td>";
+					echo get_the_date( '', $post->ID );
+					echo '</td>';
 					break;
 			}
 		}
-		print "</tr>";
+		print '</tr>';
 	}
 
 	/**
@@ -293,13 +298,16 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	 * @param $post WP_Post
 	 * @since 0.3.2
 	 */
-	function column_cb( $post ) { ?>
-		<label class="screen-reader-text" for="cb-select-<?php echo $post->ID; ?>"><?php
-				printf( __( 'Select %s' ), _draft_or_post_title() );
-		?></label>
+	function column_cb( $post ) {
+		?>
+		<label class="screen-reader-text" for="cb-select-<?php echo $post->ID; ?>">
+																	<?php
+																	printf( __( 'Select %s' ), _draft_or_post_title() );
+																	?>
+		</label>
 		<input id="cb-select-<?php echo $post->ID; ?>" type="checkbox" class="cb-select" name="post[]" value="<?php the_ID(); ?>" />
 		<div class="locked-indicator"></div>
-	<?php
+		<?php
 	}
 
 	/**
@@ -308,7 +316,7 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	 * @since 0.3.2
 	 */
 	protected function handle_row_actions( $item, $column_name, $primary ) {
-		return '<div class="row-actions"><a href="' . get_edit_post_link($item->ID, '') . '" target="_new">Edit</a></div>';
+		return '<div class="row-actions"><a href="' . get_edit_post_link( $item->ID, '' ) . '" target="_new">Edit</a></div>';
 	}
 
 	/**
@@ -319,20 +327,20 @@ class Saved_Links_List_Table extends clone_WP_List_Table {
 	 * @since 0.3.2
 	 */
 	protected function display_tablenav( $which ) {
-?>
+		?>
 	<div class="tablenav <?php echo esc_attr( $which ); ?>">
 
 		<div class="alignleft actions bulkactions">
 			<?php $this->bulk_actions( $which ); ?>
 		</div>
-<?php
+		<?php
 		$this->extra_tablenav( $which );
 		$this->pagination( $which );
-?>
+		?>
 
 		<br class="clear" />
 	</div>
-<?php
+		<?php
 	}
 
 }

--- a/inc/saved-links/class-saved-links.php
+++ b/inc/saved-links/class-saved-links.php
@@ -19,8 +19,9 @@ class SavedLinks {
 		/*Register the custom post type of for saved links: rounduplinks */
 		add_action( 'init', array( __CLASS__, 'register_post_type' ) );
 
-		/*Register our custom taxonomy of "argo-link-categories" so we can have our own tags/categories for our Argo Links post type*/
-		/* moved into a function per wordpress 3.0 issues with calling it directly*/
+		/*
+		Register our custom taxonomy of "argo-link-categories" so we can have our own tags/categories for our Argo Links post type*/
+		/* moved into a function per WordPress 3.0 issues with calling it directly*/
 		add_action( 'init', array( __CLASS__, 'register_rounduplinks_taxonomy' ) );
 
 		/* Add the Add Browser Bookmark submenu */
@@ -33,7 +34,7 @@ class SavedLinks {
 		add_action( 'save_post', array( __CLASS__, 'save_custom_fields' ) );
 
 		/*Add our new custom post fields to the display columns on the main Argo Links admin page*/
-		add_filter( 'manage_edit-rounduplink_columns', array( __CLASS__, 'display_custom_columns') );
+		add_filter( 'manage_edit-rounduplink_columns', array( __CLASS__, 'display_custom_columns' ) );
 
 		/*Populate those new columns with the custom data*/
 		add_action( 'manage_posts_custom_column', array( __CLASS__, 'data_for_custom_columns' ) );
@@ -44,13 +45,13 @@ class SavedLinks {
 		/* Argo links have no content, so we have to generate it on request */
 		add_filter( 'the_content', array( __CLASS__, 'the_content' ) );
 		add_filter( 'the_excerpt', array( __CLASS__, 'the_excerpt' ) );
-		add_filter( 'post_type_link', array( __CLASS__, 'the_permalink' ), 0, 2);
+		add_filter( 'post_type_link', array( __CLASS__, 'the_permalink' ), 0, 2 );
 		add_filter( 'author_link ', array( __CLASS__, 'the_permalink' ) );
 		add_filter( 'the_author', array( __CLASS__, 'the_author' ) );
 		add_filter( 'the_author_posts_link', array( __CLASS__, 'the_author_posts_link' ) );
 
 		/* If we have any admin_notices, print them */
-		add_action('admin_notices', array(__CLASS__, 'admin_notices'));
+		add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
 
 		/* Register a shortcode to display links */
 		add_shortcode( 'rounduplink', array( __CLASS__, 'rounduplink_shortcode' ) );
@@ -67,28 +68,31 @@ class SavedLinks {
 	 * @since 0.1
 	 */
 	public static function register_post_type() {
-		register_post_type( 'rounduplink', array(
-			'labels' 		=> array(
-				'name' 					=> __( 'Saved Links', 'link-roundups' ),
-				'singular_name' 		=> __( 'Saved Link', 'link-roundups' ),
-				'add_new' 				=> __( 'New Saved Link', 'link-roundups' ),
-				'add_new_item' 			=> __( 'New Saved Link', 'link-roundups' ),
-				'edit' 					=> __( 'Edit', 'link-roundups' ),
-				'edit_item' 			=> __( 'Edit Saved Link', 'link-roundups' ),
-				'view' 					=> __( 'View', 'link-roundups' ),
-				'view_item' 			=> __( 'View Saved Link', 'link-roundups' ),
-				'search_items' 			=> __( 'Search Saved Links', 'link-roundups' ),
-				'not_found' 			=> __( 'No Saved Links found', 'link-roundups' ),
-				'not_found_in_trash' 	=> __( 'No Saved Links found in Trash', 'link-roundups' ),
-			),
-			'description' 	=> __( 'Saved Links', 'link-roundups' ),
-			'supports' 		=> array( 'title', 'thumbnail' ),
-			'public' 		=> true, // https://github.com/INN/link-roundups/issues/120
-			'menu_position' => 6,
-			'menu_icon'     => 'dashicons-admin-links',
-			'taxonomies' 	=> array(),
-			'has_archive' 	=> true
-		));
+		register_post_type(
+			'rounduplink',
+			array(
+				'labels'        => array(
+					'name'               => __( 'Saved Links', 'link-roundups' ),
+					'singular_name'      => __( 'Saved Link', 'link-roundups' ),
+					'add_new'            => __( 'New Saved Link', 'link-roundups' ),
+					'add_new_item'       => __( 'New Saved Link', 'link-roundups' ),
+					'edit'               => __( 'Edit', 'link-roundups' ),
+					'edit_item'          => __( 'Edit Saved Link', 'link-roundups' ),
+					'view'               => __( 'View', 'link-roundups' ),
+					'view_item'          => __( 'View Saved Link', 'link-roundups' ),
+					'search_items'       => __( 'Search Saved Links', 'link-roundups' ),
+					'not_found'          => __( 'No Saved Links found', 'link-roundups' ),
+					'not_found_in_trash' => __( 'No Saved Links found in Trash', 'link-roundups' ),
+				),
+				'description'   => __( 'Saved Links', 'link-roundups' ),
+				'supports'      => array( 'title', 'thumbnail' ),
+				'public'        => true, // https://github.com/INN/link-roundups/issues/120
+				'menu_position' => 6,
+				'menu_icon'     => 'dashicons-admin-links',
+				'taxonomies'    => array(),
+				'has_archive'   => true,
+			)
+		);
 	}
 
 	public static function change_publish_button( $translation, $text ) {
@@ -114,19 +118,19 @@ class SavedLinks {
 	 */
 	public static function register_rounduplinks_taxonomy() {
 		register_taxonomy(
-			"lr-tags",
+			'lr-tags',
 			'rounduplink',
 			array(
-				'hierarchical' => false,
-				'label' => __( 'Saved Link Tags', 'link-roundups' ),
+				'hierarchical'   => false,
+				'label'          => __( 'Saved Link Tags', 'link-roundups' ),
 				'singular_label' => __( 'Saved Link Tag', 'link-roundups' ),
-				'rewrite' => true
+				'rewrite'        => true,
 			)
 		);
 	}
 
 	/**
-	 * Tell Wordpress where to put our custom fields for our custom post type
+	 * Tell WordPress where to put our custom fields for our custom post type
 	 *
 	 * @since 0.1
 	 */
@@ -136,7 +140,8 @@ class SavedLinks {
 			__( 'Link Information', 'link-roundups' ),
 			array( __CLASS__, 'display_custom_fields' ),
 			'rounduplink',
-			'normal','low'
+			'normal',
+			'low'
 		);
 	}
 
@@ -150,13 +155,13 @@ class SavedLinks {
 		global $post;
 		$custom = get_post_custom( $post->ID );
 
-		if ( isset( $custom['lr_url'][0] ) ) {
+		if ( isset( $custom ) && isset( $custom['lr_url'] ) && isset( $custom['lr_url'][0] ) ) {
 			$link_url = $custom['lr_url'][0];
 		} else {
 			$link_url = apply_filters( 'default_link_url', '' );
 		}
 
-		if ( isset( $custom['lr_desc'][0] ) ) {
+		if ( isset( $custom ) && isset( $custom['lr_desc'] ) && isset( $custom['lr_desc'][0] ) ) {
 			$link_description = $custom['lr_desc'][0];
 		} else {
 			$link_description = apply_filters( 'default_link_description', '' );
@@ -170,19 +175,23 @@ class SavedLinks {
 
 		$link_img_src = Save_To_Site_Button::default_imgUrl();
 
-	?>
+		?>
 	<p>
 		<label><?php _e( 'URL:', 'link-roundups' ); ?></label><br />
 		<input type='text' name='lr_url' value='<?php echo $link_url; ?>' style='width:98%;'/>
 	</p>
 
 	<p>
-		<label><?php _e ( 'Description:', 'link-roundups' ); ?></label><br />
+		<label><?php _e( 'Description:', 'link-roundups' ); ?></label><br />
 		<?php
-			wp_editor($link_description, 'lr_desc', array(
-				'teeny' => true,
-				'media_buttons' => false
-			));
+			wp_editor(
+				$link_description,
+				'lr_desc',
+				array(
+					'teeny'         => true,
+					'media_buttons' => false,
+				)
+			);
 		?>
 	</p>
 
@@ -191,13 +200,14 @@ class SavedLinks {
 		<input type='text' name='lr_source' value='<?php echo $link_source; ?>' style='width:98%;'/>
 	</p>
 
-	<?php if( $link_img_src ) { ?>
+		<?php if ( $link_img_src ) { ?>
 		<p><label><?php _e( 'Import featured image:', 'link-roundups' ); ?></label><br />
-		<img src="<?php echo $link_img_src ?>" width="300" />
+		<img src="<?php echo $link_img_src; ?>" width="300" />
 		<input type='hidden' name='argo_link_img_url' value='<?php echo $link_img_src; ?>'/><br>
 		<input type="checkbox" value="1" name="lr_img" id="lr_img"><label for="lr_img"><?php _e( 'Import as feature image', 'link-roundups' ); ?></label>
 		</p>
-	<?php }
+			<?php
+		}
 	}
 
 	/**
@@ -205,24 +215,26 @@ class SavedLinks {
 	 *
 	 * @since 0.1
 	 */
-	public static function save_custom_fields($post_id) {
+	public static function save_custom_fields( $post_id ) {
 
-		if ( isset( $_POST['lr_url'] ) )
-			update_post_meta( ( isset($_POST['post_ID'] ) ? $_POST['post_ID'] : $post_id ), 'lr_url', $_POST['lr_url'] );
+		if ( isset( $_POST['lr_url'] ) ) {
+			update_post_meta( ( isset( $_POST['post_ID'] ) ? $_POST['post_ID'] : $post_id ), 'lr_url', $_POST['lr_url'] );
+		}
 
-		if ( isset( $_POST["lr_desc"] ) )
-			update_post_meta( ( isset($_POST['post_ID'] ) ? $_POST['post_ID'] : $post_id ), 'lr_desc', $_POST['lr_desc'] );
+		if ( isset( $_POST['lr_desc'] ) ) {
+			update_post_meta( ( isset( $_POST['post_ID'] ) ? $_POST['post_ID'] : $post_id ), 'lr_desc', $_POST['lr_desc'] );
+		}
 
-
-		if ( isset( $_POST['lr_source'] ) )
+		if ( isset( $_POST['lr_source'] ) ) {
 			update_post_meta( ( isset( $_POST['post_ID'] ) ? $_POST['post_ID'] : $post_id ), 'lr_source', $_POST['lr_source'] );
+		}
 
 		if ( isset( $_POST['lr_img'] ) && $_POST['lr_img'] ) {
 			$attachment_id = self::lroundups_media_sideload_image( $_POST['argo_link_img_url'], $post_id );
-			if( !empty( $attachment_id ) && !is_wp_error( $attachment_id )  ) {
+			if ( ! empty( $attachment_id ) && ! is_wp_error( $attachment_id ) ) {
 				update_post_meta( ( isset( $_POST['post_ID'] ) ? $_POST['post_ID'] : $post_id ), '_thumbnail_id', $attachment_id );
 			} else {
-				self::add_notice('error', 'Unable to import featured image.');
+				self::add_notice( 'error', 'Unable to import featured image.' );
 			}
 		}
 	}
@@ -230,31 +242,33 @@ class SavedLinks {
 	/**
 	 * Similar to `media_sideload_image` except that it simply returns the attachment's ID on success
 	 *
-	 * @param (string) $file the url of the image to download and attach to the post
+	 * @param (string)  $file the url of the image to download and attach to the post
 	 * @param (integer) $post_id the post ID to attach the image to
-	 * @param (string) $desc an optional description for the image
+	 * @param (string)  $desc an optional description for the image
 	 *
 	 * @since 0.1
 	 */
 	public static function lroundups_media_sideload_image( $file, $post_id, $desc = null ) {
-		if ( !empty( $file ) ) {
+		if ( ! empty( $file ) ) {
 			// Set variables for storage, fix file filename for query strings.
 			preg_match( '/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file, $matches );
-			$file_array = array();
+			$file_array         = array();
 			$file_array['name'] = basename( $matches[0] );
 
 			// Download file to temp location.
 			$file_array['tmp_name'] = download_url( $file );
 
 			// If error storing temporarily, return the error.
-			if ( is_wp_error( $file_array['tmp_name'] ) )
+			if ( is_wp_error( $file_array['tmp_name'] ) ) {
 				return $file_array['tmp_name'];
+			}
 
 			// Do the validation and storage stuff.
 			$id = media_handle_sideload( $file_array, $post_id, $desc );
 			// If error storing permanently, unlink.
-			if ( is_wp_error( $id ) )
+			if ( is_wp_error( $id ) ) {
 				@unlink( $file_array['tmp_name'] );
+			}
 
 			return $id;
 		}
@@ -265,15 +279,15 @@ class SavedLinks {
 	 *
 	 * @since 0.1
 	 */
-	public static function display_custom_columns($columns){
+	public static function display_custom_columns( $columns ) {
 		$columns = array(
-			'cb' => '<input type=\"checkbox\" />',
-			'title' => __( 'Link Title', 'link-roundups' ),
-			'author' => __( 'Author', 'link-roundups' ),
-			'url' => __( 'URL', 'link-roundups' ),
+			'cb'          => '<input type=\"checkbox\" />',
+			'title'       => __( 'Link Title', 'link-roundups' ),
+			'author'      => __( 'Author', 'link-roundups' ),
+			'url'         => __( 'URL', 'link-roundups' ),
 			'description' => __( 'Description', 'link-roundups' ),
-			'link-tags' => __( 'Tags', 'link-roundups' ),
-			'date' => __( 'Date', 'link-roundups' )
+			'link-tags'   => __( 'Tags', 'link-roundups' ),
+			'date'        => __( 'Date', 'link-roundups' ),
 		);
 		return $columns;
 	}
@@ -283,23 +297,27 @@ class SavedLinks {
 	 *
 	 * @since 0.1
 	 */
-	public static function data_for_custom_columns($column){
+	public static function data_for_custom_columns( $column ) {
 		global $post;
 		$custom = get_post_custom();
 
-		switch ($column) {
+		switch ( $column ) {
 
 			case 'description':
-				echo $custom['lr_desc'][0];
+				if ( isset( $custom['lr_desc'] ) && isset( $custom['lr_desc'][0] ) ) {
+					echo $custom['lr_desc'][0];
+				}
 				break;
 
 			case 'url':
-				echo $custom["lr_url"][0];
+				if ( isset( $custom['lr_url'] ) && isset( $custom['lr_url'][0] ) ) {
+					echo $custom['lr_url'][0];
+				}
 				break;
 
 			case 'link-tags':
 				$base_url = 'edit.php?post_type=rounduplink';
-				$terms = get_the_terms( $post->ID, 'lr-tags' );
+				$terms    = get_the_terms( $post->ID, 'lr-tags' );
 				if ( is_array( $terms ) ) {
 					$term_links = array();
 					foreach ( $terms as $term ) {
@@ -330,7 +348,8 @@ class SavedLinks {
 				apply_filters( 'link_roundups_minimum_capability', 'edit_posts' ),
 				'install-browser-bookmark',
 				array(
-					__CLASS__, 'build_lroundups_page'
+					__CLASS__,
+					'build_lroundups_page',
 				)
 			);
 		} else {
@@ -341,7 +360,8 @@ class SavedLinks {
 				apply_filters( 'link_roundups_minimum_capability', 'edit_posts' ),
 				'install-browser-bookmark',
 				array(
-					__CLASS__, 'build_lroundups_page_admonition'
+					__CLASS__,
+					'build_lroundups_page_admonition',
 				)
 			);
 		}
@@ -355,42 +375,44 @@ class SavedLinks {
 	 */
 	public static function build_lroundups_page_admonition() {
 		/** WordPress Administration Bootstrap */
-		include_once( ABSPATH  . 'wp-admin/admin.php' );
+		include_once ABSPATH . 'wp-admin/admin.php';
 		?>
 			<h2><?php _e( 'Enable Save to Site bookmarklet for your site', 'link-roundups' ); ?></h2>
 
 			<div class="tool-box">
 				<div class="card">
-					<h3><?php _e( 'Save to Site', 'link-roundups' ) ?></h3>
-					<p><?php _e( 'Save to Site is a tool that lets you send Saved Links to your WordPress Dashboard while browsing the web.', 'link-roundups' );?></p>
-					<p><?php
+					<h3><?php _e( 'Save to Site', 'link-roundups' ); ?></h3>
+					<p><?php _e( 'Save to Site is a tool that lets you send Saved Links to your WordPress Dashboard while browsing the web.', 'link-roundups' ); ?></p>
+					<p>
+					<?php
 						printf(
 							// translators: %1$s is https://wordpress.org/plugins/press-this/
 							'Your website is not currently capable of generating the link used for the Save to Site bookmarklet. In order to use the Save to Site bookmarklet, you will need to install the official WordPress plugin <a href="%1$s">Press This</a>, which reimplements functionality that was removed from WordPress in version 4.9.',
 							'https://wordpress.org/plugins/press-this/'
 						);
-					?></p>
+					?>
+					</p>
 
 					<?php
-						if ( current_user_can( 'install_plugins' ) ) {
-							printf(
-								'<a class="button button-primary" href="%1$s">%2$s</a>',
-								add_query_arg(
-									array(
-										's' => htmlspecialchars('press-this'),
-										'tab' => 'search',
-										'type' => 'term',
-									),
-									network_admin_url( 'plugin-install.php' )
+					if ( current_user_can( 'install_plugins' ) ) {
+						printf(
+							'<a class="button button-primary" href="%1$s">%2$s</a>',
+							add_query_arg(
+								array(
+									's'    => htmlspecialchars( 'press-this' ),
+									'tab'  => 'search',
+									'type' => 'term',
 								),
-								'Install now'
-							);
-						} else {
-							printf(
-								'<p>%1$s</p>',
-								__( 'Please contact your site administrator to have this plugin installed.', 'link-roundups' )
-							);
-						}
+								network_admin_url( 'plugin-install.php' )
+							),
+							'Install now'
+						);
+					} else {
+						printf(
+							'<p>%1$s</p>',
+							__( 'Please contact your site administrator to have this plugin installed.', 'link-roundups' )
+						);
+					}
 					?>
 				</div>
 			</div>
@@ -404,17 +426,17 @@ class SavedLinks {
 	 * @since 0.1
 	 */
 	public static function build_lroundups_page() {
-	/** WordPress Administration Bootstrap */
-	include_once( ABSPATH  . 'wp-admin/admin.php' );
-	?>
+		/** WordPress Administration Bootstrap */
+		include_once ABSPATH . 'wp-admin/admin.php';
+		?>
 
 	<h2><?php _e( 'Add Save to Site Bookmark to Your Web Browser', 'link-roundups' ); ?></h2>
 
 	<div class="tool-box">
 
 	<div class="card pressthis">
-	<h3><?php _e( 'Save to Site', 'link-roundups' ) ?></h3>
-	<p><?php _e( 'Save to Site is a tool that lets you send Saved Links to your WordPress Dashboard while browsing the web.', 'link-roundups' );?></p>
+	<h3><?php _e( 'Save to Site', 'link-roundups' ); ?></h3>
+	<p><?php _e( 'Save to Site is a tool that lets you send Saved Links to your WordPress Dashboard while browsing the web.', 'link-roundups' ); ?></p>
 	<p><?php _e( 'Click the Save to Site bookmark and a new WordPress window will popup, attempting to prefill Title, URL and Source information.', 'link-roundups' ); ?></p>
 
 
@@ -427,13 +449,13 @@ class SavedLinks {
 			<a class="pressthis-bookmarklet" onclick="return false;" href="<?php echo Save_To_Site_Button::shortcut_link(); ?>"><span><?php _e( 'Save to Site', 'link-roundups' ); ?></span></a>
 			<button type="button" class="button button-secondary pressthis-js-toggle js-show-pressthis-code-wrap" aria-expanded="false" aria-controls="pressthis-code-wrap">
 				<span class="dashicons dashicons-clipboard"></span>
-				<span class="screen-reader-text"><?php _e( 'Copy Save to Site bookmarklet code', 'link-roundups' ) ?></span>
+				<span class="screen-reader-text"><?php _e( 'Copy Save to Site bookmarklet code', 'link-roundups' ); ?></span>
 			</button>
 		</p>
 
 		<div class="hidden js-pressthis-code-wrap clear" id="pressthis-code-wrap">
 			<p id="pressthis-code-desc">
-				<?php _e( 'If you can&#8217;t drag the bookmarklet to your bookmarks, copy the following code and create a new bookmark. Paste the code into the new bookmark&#8217;s URL field.', 'link-roundups' ) ?>
+				<?php _e( 'If you can&#8217;t drag the bookmarklet to your bookmarks, copy the following code and create a new bookmark. Paste the code into the new bookmark&#8217;s URL field.', 'link-roundups' ); ?>
 			</p>
 			<p>
 				<textarea class="js-pressthis-code" rows="5" cols="120" readonly="readonly" aria-labelledby="pressthis-code-desc"><?php echo esc_attr( Save_to_Site_Button::shortcut_link() ); ?></textarea>
@@ -444,7 +466,7 @@ class SavedLinks {
 		<p><?php _e( 'Follow the link to open Save to Site. Then add it to your device&#8217;s bookmarks or home screen.', 'link-roundups' ); ?></p>
 
 		<p>
-			<a class="button button-secondary" href="<?php echo Save_To_Site_Button::shortcut_link(); ?>"><?php _e( 'Open Save to Site', 'link-roundups' ) ?></a>
+			<a class="button button-secondary" href="<?php echo Save_To_Site_Button::shortcut_link(); ?>"><?php _e( 'Open Save to Site', 'link-roundups' ); ?></a>
 		</p>
 		<script>
 			jQuery( document ).ready( function( $ ) {
@@ -469,7 +491,7 @@ class SavedLinks {
 	</form>
 </div>
 	</div>
-<?php
+		<?php
 	}
 
 	public static function add_saved_links_widget() {
@@ -490,17 +512,17 @@ class SavedLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function the_permalink($url, $post=null) {
+	public static function the_permalink( $url, $post = null ) {
 		$post = get_post( $post );
 
 		// Only run for argo_links
-		$meta = get_post_meta( $post->ID );
-		$remoteUrl = !empty( $meta['lr_url'] ) ? $meta['lr_url'][0] : '';
+		$meta      = get_post_meta( $post->ID );
+		$remoteUrl = ! empty( $meta['lr_url'] ) ? $meta['lr_url'][0] : '';
 
 		if ( empty( $remoteUrl ) || ! ( 'rounduplink' == $post->post_type ) ) {
-			remove_filter( 'post_type_link', array( __CLASS__, 'the_permalink' ), 0, 2);
+			remove_filter( 'post_type_link', array( __CLASS__, 'the_permalink' ), 0, 2 );
 			$permalink = get_permalink( $post->ID );
-			add_filter( 'post_type_link', array( __CLASS__, 'the_permalink' ), 0, 2);
+			add_filter( 'post_type_link', array( __CLASS__, 'the_permalink' ), 0, 2 );
 			return $permalink;
 		}
 
@@ -518,16 +540,16 @@ class SavedLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function the_author($author) {
+	public static function the_author( $author ) {
 		// Only run for argo_links
 		global $post;
 
 		$default = '';
 
-		$meta = get_post_meta($post->ID);
-		$source = !empty( $meta['lr_source'] ) ? $meta['lr_source'][0] : $default;
+		$meta   = get_post_meta( $post->ID );
+		$source = ! empty( $meta['lr_source'] ) ? $meta['lr_source'][0] : $default;
 
-		if ( empty( $source ) || !( 'rounduplink' == $post->post_type ) ) {
+		if ( empty( $source ) || ! ( 'rounduplink' == $post->post_type ) ) {
 			return $author;
 		}
 
@@ -542,16 +564,16 @@ class SavedLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function the_author_posts_link($link) {
+	public static function the_author_posts_link( $link ) {
 		global $post;
 
-		if ( !( 'rounduplink' == $post->post_type ) ) {
+		if ( ! ( 'rounduplink' == $post->post_type ) ) {
 			return $link;
 		}
 
-		$meta = get_post_meta( $post->ID );
-		$url = self::the_permalink( $post ); //! empty( $meta['lr_url'] ) ? $meta['lr_url'][0] : '';
-		$title = get_the_title( $post->ID );
+		$meta   = get_post_meta( $post->ID );
+		$url    = self::the_permalink( $post ); // ! empty( $meta['lr_url'] ) ? $meta['lr_url'][0] : '';
+		$title  = get_the_title( $post->ID );
 		$source = ! empty( $meta['lr_source'] ) ? $meta['lr_source'][0] : '';
 
 		$link = sprintf(
@@ -574,7 +596,7 @@ class SavedLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function the_content($content) {
+	public static function the_content( $content ) {
 		// Only run for roundup links
 		global $post;
 
@@ -603,7 +625,7 @@ class SavedLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function the_excerpt($content) {
+	public static function the_excerpt( $content ) {
 		global $post;
 
 		// Only run for argo_links
@@ -624,7 +646,7 @@ class SavedLinks {
 	 *
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
-	public static function get_html($post=null, $link_class=null, $attrs=array()) {
+	public static function get_html( $post = null, $link_class = null, $attrs = array() ) {
 		$post = get_post( $post );
 
 		if ( ! $post ) {
@@ -634,9 +656,9 @@ class SavedLinks {
 		$meta = get_post_meta( $post->ID );
 
 		if ( $post->post_type == 'rounduplink' ) {
-			$url = !empty($meta['lr_url'])? $meta['lr_url'][0] : '';
+			$url         = ! empty( $meta['lr_url'] ) ? $meta['lr_url'][0] : '';
 			$description = array_key_exists( 'lr_desc', $meta ) ? $meta['lr_desc'][0] : '';
-			$source = ! empty( $meta['lr_source'] ) ? $meta['lr_source'][0] : '';
+			$source      = ! empty( $meta['lr_source'] ) ? $meta['lr_source'][0] : '';
 		} else {
 			// Fallback when post types other than 'rounduplink' are used in Link Roundups
 			if ( ! empty( $meta['lr_url'] ) && ! empty( $meta['lr_url'][0] ) ) {
@@ -647,13 +669,13 @@ class SavedLinks {
 
 			if ( ! empty( $meta['lr_desc'] ) && ! empty( $meta['lr_desc'][0] ) ) {
 				$description = $meta['lr_desc'][0];
-			} else if ( ! empty( $post->post_excerpt ) ) {
+			} elseif ( ! empty( $post->post_excerpt ) ) {
 				$description = $post->post_excerpt;
 			} else {
 				$description = $post->post_content;
 			}
 
-			if ( ! empty( $meta['lr_source'] ) && ! empty( $meta['lr_source'][0] )  ) {
+			if ( ! empty( $meta['lr_source'] ) && ! empty( $meta['lr_source'][0] ) ) {
 				$source = $meta['lr_source'][0];
 			} else {
 				$source = get_bloginfo( 'name' );
@@ -684,17 +706,17 @@ class SavedLinks {
 			$lroundups_html = self::lroundups_default_link_html();
 		}
 
-		$lroundups_html = str_replace('#!URL!#', $url, $lroundups_html);
-		$lroundups_html = str_replace('#!TITLE!#', $title, $lroundups_html);
-		$lroundups_html = str_replace('#!DESCRIPTION!#', $description, $lroundups_html);
-		$lroundups_html = str_replace('#!SOURCE!#', $source, $lroundups_html);
-		$lroundups_html = str_replace('#!CLASS!#', $link_class, $lroundups_html);
+		$lroundups_html = str_replace( '#!URL!#', $url, $lroundups_html );
+		$lroundups_html = str_replace( '#!TITLE!#', $title, $lroundups_html );
+		$lroundups_html = str_replace( '#!DESCRIPTION!#', $description, $lroundups_html );
+		$lroundups_html = str_replace( '#!SOURCE!#', $source, $lroundups_html );
+		$lroundups_html = str_replace( '#!CLASS!#', $link_class, $lroundups_html );
 
 		if ( has_post_thumbnail( $post->ID ) ) {
 			$lroundups_html = str_replace( '#!IMAGE!#', get_the_post_thumbnail( $post->ID ), $lroundups_html );
-		 } else {
-			 $lroundups_html = str_replace( '#!IMAGE!#', '', $lroundups_html );
-		 }
+		} else {
+			$lroundups_html = str_replace( '#!IMAGE!#', '', $lroundups_html );
+		}
 
 		return $lroundups_html;
 	}
@@ -707,14 +729,14 @@ class SavedLinks {
 	public static function rounduplink_shortcode( $atts ) {
 		$a = shortcode_atts(
 			array(
-				'id' => '',
+				'id'    => '',
 				'title' => '',
-				'class' => ''
+				'class' => '',
 			),
 			$atts
 		);
 
-		$link_class = (!empty($a['class']))? ' ' . $a['class'] : '';
+		$link_class = ( ! empty( $a['class'] ) ) ? ' ' . $a['class'] : '';
 
 		// send it all over to get_html (see above)
 		if ( $a['id'] != null ) {
@@ -736,15 +758,16 @@ class SavedLinks {
 	 * @param string $content content passed in by the filter (should be empty).
 	 */
 	public static function get_excerpt( $post ) {
-		$post = get_post( $post );
+		$post   = get_post( $post );
 		$custom = get_post_meta( $post->ID );
 
 		ob_start();
-		if ( isset( $custom['lr_desc'][0] ) )
+		if ( isset( $custom['lr_desc'][0] ) ) {
 			echo '<p class="description">' . $custom['lr_desc'][0] . '</p>';
+		}
 		if ( isset( $custom['lr_source'][0] ) && ( $custom['lr_source'][0] != '' ) ) {
-			echo '<p class="source">' . __('Source: ', 'link-roundups') . '<span>';
-			echo isset( $custom['lr_url'][0] ) ? '<a href="' . $custom["lr_url"][0] . '">' . $custom["lr_source"][0] . '</a>' : $custom["lr_source"][0];
+			echo '<p class="source">' . __( 'Source: ', 'link-roundups' ) . '<span>';
+			echo isset( $custom['lr_url'][0] ) ? '<a href="' . $custom['lr_url'][0] . '">' . $custom['lr_source'][0] . '</a>' : $custom['lr_source'][0];
 			echo '</span></p>';
 		}
 		$html = ob_get_clean();
@@ -758,7 +781,7 @@ class SavedLinks {
 	 * @since 0.3.2
 	 */
 	public static function lroundups_saved_links_list_table_render() {
-		require_once( __DIR__ . '/class-saved-links-list-table.php' );
+		require_once __DIR__ . '/class-saved-links-list-table.php';
 
 		// Set up and generate the table.
 		$links_list_table = new Saved_Links_List_Table();
@@ -775,9 +798,9 @@ class SavedLinks {
 	 *
 	 * @since 0.3.2
 	 */
-	public static function add_notice($type, $message) {
-		self::$notices[] = array($type, urlencode($message));
-		add_filter('redirect_post_location', array(__CLASS__, 'add_notice_query_var'), 99);
+	public static function add_notice( $type, $message ) {
+		self::$notices[] = array( $type, urlencode( $message ) );
+		add_filter( 'redirect_post_location', array( __CLASS__, 'add_notice_query_var' ), 99 );
 	}
 
 	/**
@@ -785,10 +808,10 @@ class SavedLinks {
 	 *
 	 * @since 0.3.2
 	 */
-	public static function add_notice_query_var($location) {
-		if (!empty(self::$notices)) {
-			remove_filter('redirect_post_location', array(__CLASS__, 'add_notice_query_var'), 99);
-			return add_query_arg(array('lroundups_notices' => self::$notices), $location);
+	public static function add_notice_query_var( $location ) {
+		if ( ! empty( self::$notices ) ) {
+			remove_filter( 'redirect_post_location', array( __CLASS__, 'add_notice_query_var' ), 99 );
+			return add_query_arg( array( 'lroundups_notices' => self::$notices ), $location );
 		}
 	}
 
@@ -798,20 +821,25 @@ class SavedLinks {
 	 * @since 0.3.2
 	 */
 	public static function admin_notices() {
-		if (!isset($_GET['lroundups_notices']))
+		if ( ! isset( $_GET['lroundups_notices'] ) ) {
 			return;
+		}
 
-		foreach ($_GET['lroundups_notices'] as $notice) { ?>
-			<div class="<?php echo $notice[0]; ?>"><p><?php echo urldecode($notice[1]); ?></p></div>
-	<?php }
+		foreach ( $_GET['lroundups_notices'] as $notice ) {
+			?>
+			<div class="<?php echo $notice[0]; ?>"><p><?php echo urldecode( $notice[1] ); ?></p></div>
+			<?php
+		}
 	}
 
 	public static function lroundups_default_link_html() {
-		ob_start(); ?>
+		ob_start();
+		?>
 		<p class="lr-saved-link #!CLASS!#">
 			#!IMAGE!#
 			<a href="#!URL!#">#!TITLE!#</a>&ndash;<span class="description">#!DESCRIPTION!#</span> <em>#!SOURCE!#</em>
-		</p><?php
+		</p>
+		<?php
 		return ob_get_clean();
 	}
 }

--- a/inc/saved-links/class-wp-list-table-clone.php
+++ b/inc/saved-links/class-wp-list-table-clone.php
@@ -236,8 +236,8 @@ class clone_WP_List_Table {
 	 *
 	 * @since 4.0.0
 	 *
-	 * @param string   $name      Method to call.
-	 * @param array    $arguments Arguments to pass when calling.
+	 * @param string $name      Method to call.
+	 * @param array  $arguments Arguments to pass when calling.
 	 * @return mixed|bool Return value of the callback, false otherwise.
 	 */
 	public function __call( $name, $arguments ) {
@@ -981,7 +981,7 @@ class clone_WP_List_Table {
 		// If the primary column doesn't exist fall back to the
 		// first non-checkbox column.
 		if ( ! isset( $columns[ $default ] ) ) {
-			$default = clone_WP_List_Table::get_default_primary_column_name();
+			$default = self::get_default_primary_column_name();
 		}
 
 		/**

--- a/inc/updates/functions.php
+++ b/inc/updates/functions.php
@@ -9,8 +9,8 @@
  * @since 0.3
  */
 function lroundups_update_post_types( $to, $from ) {
-	_lroundups_convert_posts( 'argolinkroundups','roundup' );
-	_lroundups_convert_posts( 'argolinks','rounduplink' );
+	_lroundups_convert_posts( 'argolinkroundups', 'roundup' );
+	_lroundups_convert_posts( 'argolinks', 'rounduplink' );
 }
 add_action( 'lroundups_update_0.3', 'lroundups_update_post_types', 10, 2 );
 
@@ -35,9 +35,10 @@ function lroundups_migrate_options() {
 	foreach ( $old_options as $old_option ) {
 		$new_option = str_replace(
 			array( 'argo_link_roundups_', 'link_roundups_' ),
-			'lroundups_', $old_option
+			'lroundups_',
+			$old_option
 		);
-		$old_value = get_option( $old_option );
+		$old_value  = get_option( $old_option );
 
 		if ( $old_value ) {
 			$result = update_option( $new_option, $old_value );
@@ -65,14 +66,15 @@ add_action( 'lroundups_update_0.3', 'lroundups_migrate_options', 10 );
  */
 function lroundups_update_post_terms( $to, $from ) {
 	$old_metas = array(
-		'argo_link_url' => 'lr_url',
-		'argo_link_description' => 'lr_desc',
-		'argo_link_source' => 'lr_source',
-		'argo_link_img_url_import' => 'lr_img'
+		'argo_link_url'            => 'lr_url',
+		'argo_link_description'    => 'lr_desc',
+		'argo_link_source'         => 'lr_source',
+		'argo_link_img_url_import' => 'lr_img',
 	);
 
-	foreach ($old_metas as $old_meta => $new_meta)
-		_lroundups_convert_posts_meta($old_meta, $new_meta);
+	foreach ( $old_metas as $old_meta => $new_meta ) {
+		_lroundups_convert_posts_meta( $old_meta, $new_meta );
+	}
 }
 add_action( 'lroundups_update_0.3.2', 'lroundups_update_post_terms', 15, 2 );
 
@@ -93,7 +95,7 @@ add_action( 'lroundups_update_0.3.2', 'lroundups_update_taxonomy_name', 20, 2 );
  * @since 0.3.2
  */
 function lroundups_delete_argolinks_flush_option() {
-	delete_option('argolinks_flush');
+	delete_option( 'argolinks_flush' );
 }
 add_action( 'lroundups_update_0.3.2', 'lroundups_delete_argolinks_flush_option', 10 );
 
@@ -108,11 +110,14 @@ add_action( 'lroundups_update_0.3.2', 'lroundups_delete_argolinks_flush_option',
  */
 function _lroundups_convert_posts( $old_post_type, $new_post_type ) {
 	global $wpdb;
-	$wpdb->query( $wpdb->prepare(
-		"UPDATE $wpdb->posts
+	$wpdb->query(
+		$wpdb->prepare(
+			"UPDATE $wpdb->posts
 		SET post_type = %s
-		WHERE post_type = %s;"
-		, $new_post_type, $old_post_type )
+		WHERE post_type = %s;",
+			$new_post_type,
+			$old_post_type
+		)
 	);
 }
 
@@ -123,11 +128,14 @@ function _lroundups_convert_posts( $old_post_type, $new_post_type ) {
  */
 function _lroundups_convert_posts_meta( $old_meta, $new_meta ) {
 	global $wpdb;
-	$wpdb->query( $wpdb->prepare(
-		"UPDATE  $wpdb->postmeta
+	$wpdb->query(
+		$wpdb->prepare(
+			"UPDATE  $wpdb->postmeta
 		SET meta_key = %s
-		WHERE meta_key = %s;"
-		, $new_meta, $old_meta )
+		WHERE meta_key = %s;",
+			$new_meta,
+			$old_meta
+		)
 	);
 }
 
@@ -138,10 +146,13 @@ function _lroundups_convert_posts_meta( $old_meta, $new_meta ) {
  */
 function _lroundups_convert_taxonomy_name( $old_tax, $new_tax ) {
 	global $wpdb;
-	$wpdb->query( $wpdb->prepare(
-		"UPDATE $wpdb->term_taxonomy
+	$wpdb->query(
+		$wpdb->prepare(
+			"UPDATE $wpdb->term_taxonomy
 		SET taxonomy = %s
-		WHERE taxonomy = %s;"
-		, $new_tax, $old_tax )
+		WHERE taxonomy = %s;",
+			$new_tax,
+			$old_tax
+		)
 	);
 }

--- a/inc/updates/index.php
+++ b/inc/updates/index.php
@@ -27,16 +27,16 @@ function lroundups_perform_update() {
 		 *  · argolinkroundups → roundups
 		 *  · argolinks → rounduplink
 		 * - Migrate Plugin Options
-		 *		 All argo_link_* and link_roundups_* dropped in favor of lroundups_*
-		 *		 --------------------------------------------------------
-		 *		'argo_link_roundups_custom_url'
-		 * 		'argo_link_roundups_custom_html'
-		 * 		'link_roundups_custom_name_singular'
-		 * 		'link_roundups_custom_name_plural'
-		 * 		'argo_link_roundups_use_mailchimp_integration'
-		 * 		'argo_link_roundups_mailchimp_api_key'
-		 * 		'argo_link_mailchimp_template'
-		 * 		'argo_link_mailchimp_list'
+		 *       All argo_link_* and link_roundups_* dropped in favor of lroundups_*
+		 *       --------------------------------------------------------
+		 *      'argo_link_roundups_custom_url'
+		 *      'argo_link_roundups_custom_html'
+		 *      'link_roundups_custom_name_singular'
+		 *      'link_roundups_custom_name_plural'
+		 *      'argo_link_roundups_use_mailchimp_integration'
+		 *      'argo_link_roundups_mailchimp_api_key'
+		 *      'argo_link_mailchimp_template'
+		 *      'argo_link_mailchimp_list'
 		 * ------------------------------------------------------ */
 		do_action( 'lroundups_update_0.3', lroundups_version(), get_option( 'lroundups_version' ) );
 
@@ -50,7 +50,7 @@ function lroundups_perform_update() {
 		 *  · lr_source → lr_source
 		 *  · lr_img → lr_img
 		 * ------------------------------------------------------ */
-		do_action( 'lroundups_update_0.3.2', lroundups_version(), get_option('lroundups_version') );
+		do_action( 'lroundups_update_0.3.2', lroundups_version(), get_option( 'lroundups_version' ) );
 
 		// Set version.
 		update_option( 'lroundups_version', lroundups_version() );
@@ -65,7 +65,7 @@ function lroundups_perform_update() {
  * @since 0.3
  */
 function lroundups_version() {
-	if( is_admin() ) {
+	if ( is_admin() ) {
 		$plugin = get_plugin_data( plugin_dir_path( LROUNDUPS_PLUGIN_FILE ) . '/link-roundups.php' );
 		return $plugin['Version'];
 	}
@@ -76,6 +76,7 @@ function lroundups_version() {
 /**
  * Checks if updates need to be run.
  * Get's lroundups version from db and compares with value in plugin file
+ *
  * @since 0.3
  *
  * @return boolean if updates need to be run
@@ -116,24 +117,26 @@ function lroundups_need_updates() {
  * @since 0.3
  */
 function lroundups_update_admin_notice() {
-	if ( lroundups_need_updates() && !( isset( $_GET['page'] ) && $_GET['page'] == 'update-lroundups' ) ) {
-	?>
+	if ( lroundups_need_updates() && ! ( isset( $_GET['page'] ) && $_GET['page'] == 'update-lroundups' ) ) {
+		?>
 	<div class="update-nag" style="display: block;">
-		<p><?php
-			if ( current_user_can( 'update_plugins' ) ) {
-				printf(
-					__('Link Roundups has been updated! IMPORTANT: Please <a href="%s">click here</a> to run a required database upgrade.', 'link-roundups'),
-					admin_url('index.php?page=update-lroundups')
-				);
-			} else {
-				printf(
-					__('Link Roundups has been updated! IMPORTANT: Please contact your site administrator to run a required database upgrade.', 'link-roundups'),
-					admin_url('index.php?page=update-lroundups')
-				);
-			}
-		?></p>
+		<p>
+		<?php
+		if ( current_user_can( 'update_plugins' ) ) {
+			printf(
+				__( 'Link Roundups has been updated! IMPORTANT: Please <a href="%s">click here</a> to run a required database upgrade.', 'link-roundups' ),
+				admin_url( 'index.php?page=update-lroundups' )
+			);
+		} else {
+			printf(
+				__( 'Link Roundups has been updated! IMPORTANT: Please contact your site administrator to run a required database upgrade.', 'link-roundups' ),
+				admin_url( 'index.php?page=update-lroundups' )
+			);
+		}
+		?>
+		</p>
 	</div>
-	<?php
+		<?php
 	}
 }
 add_action( 'admin_notices', 'lroundups_update_admin_notice' );
@@ -145,16 +148,20 @@ add_action( 'admin_notices', 'lroundups_update_admin_notice' );
  */
 function lroundups_register_update_page() {
 	$parent_slug = null;
-	$page_title = __( 'Update Link Roundups', 'link-roundups' );
-	$menu_title = __( 'Update Link Roundups', 'link-roundups' );
-	$capability = 'edit_theme_options';
-	$menu_slug = 'update-lroundups';
-	$function = 'lroundups_update_page_view';
+	$page_title  = __( 'Update Link Roundups', 'link-roundups' );
+	$menu_title  = __( 'Update Link Roundups', 'link-roundups' );
+	$capability  = 'edit_theme_options';
+	$menu_slug   = 'update-lroundups';
+	$function    = 'lroundups_update_page_view';
 
 	if ( lroundups_need_updates() ) {
 		add_submenu_page(
-			$parent_slug, $page_title, $menu_title,
-			$capability, $menu_slug, $function
+			$parent_slug,
+			$page_title,
+			$menu_title,
+			$capability,
+			$menu_slug,
+			$function
 		);
 	}
 }
@@ -165,7 +172,8 @@ add_action( 'admin_menu', 'lroundups_register_update_page' );
  *
  * @since 0.3
  */
-function lroundups_update_page_view() { ?>
+function lroundups_update_page_view() {
+	?>
 	<style type="text/css">
 		.lroundups-update-message {
 			max-width: 700px;
@@ -201,9 +209,14 @@ function lroundups_update_page_view() { ?>
 	</style>
 	<div class="wrap">
 		<div id="icon-tools" class="icon32"></div>
-		<h2><?php _e ( 'Link Roundups Database Update', 'link-roundups' ); ?></h2>
+		<h2><?php _e( 'Link Roundups Database Update', 'link-roundups' ); ?></h2>
 		<div class="lroundups-update-message">
-			<p><?php _e( 'Link Roundups plugin has been updated to version', 'link-roundups' ); echo " " . lroundups_version(); ?>.
+			<p>
+			<?php
+			_e( 'Link Roundups plugin has been updated to version', 'link-roundups' );
+			echo ' ' . lroundups_version();
+			?>
+			.
 
 			<p><?php _e( 'This update will migrate <strong>Argo Links</strong> and <strong>Argo Link Roundups</strong> to the new <strong>Saved Links</strong> and <strong>Link Roundups</strong> formats respectively.', 'link-roundups' ); ?></p>
 			<p><?php _e( 'This process will restore previous Argo Links and Argo Link Roundups posts to your site.', 'link-roundups' ); ?></p>
@@ -216,7 +229,7 @@ function lroundups_update_page_view() { ?>
 			<p>
 		</div>
 	</div>
-<?php
+	<?php
 }
 
 /**
@@ -227,10 +240,14 @@ function lroundups_update_page_view() { ?>
  * @global $_GET
  */
 function lroundups_update_page_enqueue_js() {
-	if ( isset( $_GET['page'] ) && $_GET['page'] == 'update-lroundups') {
+	if ( isset( $_GET['page'] ) && $_GET['page'] == 'update-lroundups' ) {
 		wp_enqueue_script(
-			'lroundups_update_page', plugins_url( '/js/update.js', LROUNDUPS_PLUGIN_FILE),
-			array( 'jquery' ), false, 1 );
+			'lroundups_update_page',
+			plugins_url( '/js/update.js', LROUNDUPS_PLUGIN_FILE ),
+			array( 'jquery' ),
+			false,
+			1
+		);
 	}
 }
 add_action( 'admin_enqueue_scripts', 'lroundups_update_page_enqueue_js' );
@@ -241,35 +258,43 @@ add_action( 'admin_enqueue_scripts', 'lroundups_update_page_enqueue_js' );
  * @since 0.3
  */
 function lroundups_ajax_update_database() {
-	if (!current_user_can('activate_plugins')) {
-		print json_encode( array(
-			'status' 	=> __( 'An error occurred.', 'link-roundups' ),
-			'success' 	=> false
-		));
+	if ( ! current_user_can( 'activate_plugins' ) ) {
+		print json_encode(
+			array(
+				'status'  => __( 'An error occurred.', 'link-roundups' ),
+				'success' => false,
+			)
+		);
 		wp_die();
 	}
 
-	if (!lroundups_need_updates()) {
-		print json_encode( array(
-			'status' 	=> __( 'Finished. No update was required.', 'link-roundups' ),
-			'success' 	=> false
-		));
+	if ( ! lroundups_need_updates() ) {
+		print json_encode(
+			array(
+				'status'  => __( 'Finished. No update was required.', 'link-roundups' ),
+				'success' => false,
+			)
+		);
 		wp_die();
 	}
 
 	$ret = lroundups_perform_update();
-	if (!empty($ret)) {
+	if ( ! empty( $ret ) ) {
 		$message = __( 'Thank you -- the update is complete.', 'link-roundups' );
-		print json_encode( array(
-			'status' 	=> $message,
-			'success' 	=> true
-		));
+		print json_encode(
+			array(
+				'status'  => $message,
+				'success' => true,
+			)
+		);
 		wp_die();
 	} else {
-		print json_encode( array(
-			'status' 	=> __( 'There was a problem applying the update. Please try again.', 'link-roundups' ),
-			'success' 	=> false
-		));
+		print json_encode(
+			array(
+				'status'  => __( 'There was a problem applying the update. Please try again.', 'link-roundups' ),
+				'success' => false,
+			)
+		);
 		wp_die();
 	}
 }
@@ -280,4 +305,4 @@ add_action( 'wp_ajax_lroundups_ajax_update_database', 'lroundups_ajax_update_dat
  * Update functions.
  * ------------------------------------------------------ */
 
-include_once( __DIR__ . '/functions.php' );
+require_once __DIR__ . '/functions.php';

--- a/link-roundups.php
+++ b/link-roundups.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'MailChimp' ) && file_exists( __DIR__ . '/vendor/autoload.p
 	error_log(
 		sprintf(
 			// translators: %1$s is a URL.
-			__('Your installation of the Link Roundups Plugin is missing its vendor dependencies. Please visit %1$s for more information.', 'link-roundups'),
+			__( 'Your installation of the Link Roundups Plugin is missing its vendor dependencies. Please visit %1$s for more information.', 'link-roundups' ),
 			'https://github.com/INN/link-roundups/blob/136-update-wordpress-mailchimp-tools/docs/installation.md'
 		)
 	);
@@ -50,31 +50,30 @@ function link_roundups_init() {
 	/**
 	 * Saved Links
 	 */
-	require_once(__DIR__ . '/inc/saved-links/class-saved-links.php');
-	require_once(__DIR__ . '/inc/saved-links/class-saved-links-widget.php');
+	require_once __DIR__ . '/inc/saved-links/class-saved-links.php';
+	require_once __DIR__ . '/inc/saved-links/class-saved-links-widget.php';
 
 	/**
 	 * Link Roundups
 	 */
-	require_once(__DIR__ . '/inc/link-roundups/class-link-roundups.php');
-	require_once(__DIR__ . '/inc/link-roundups/class-link-roundups-editor.php');
-	require_once(__DIR__ . '/inc/link-roundups/class-link-roundups-widget.php');
+	require_once __DIR__ . '/inc/link-roundups/class-link-roundups.php';
+	require_once __DIR__ . '/inc/link-roundups/class-link-roundups-editor.php';
+	require_once __DIR__ . '/inc/link-roundups/class-link-roundups-widget.php';
 
 	/**
 	 * Save to Site Browser Bookmark Tool
 	 */
-	require_once(__DIR__ . '/inc/link-roundups/class-save-to-site-button.php');
+	require_once __DIR__ . '/inc/link-roundups/class-save-to-site-button.php';
 
 	/**
 	 * Add Backwards Compatability with argo-links
 	 */
-	require_once(__DIR__ . '/inc/compatibility.php');
+	require_once __DIR__ . '/inc/compatibility.php';
 
 	/**
 	 * Add compatibility filters for INN/Largo
 	 */
-	require_once(__DIR__ . '/inc/compatibility-largo.php');
-
+	require_once __DIR__ . '/inc/compatibility-largo.php';
 
 	/**
 	 * Initialize the plugin using its init() function
@@ -86,7 +85,7 @@ function link_roundups_init() {
 	/**
 	 * Include updates framework
 	 */
-	require_once( 'inc/updates/index.php' );
+	require_once 'inc/updates/index.php';
 
 	load_plugin_textdomain( 'link-roundups', false, dirname( plugin_basename( __FILE__ ) ) . '/lang' );
 }
@@ -99,16 +98,22 @@ add_action( 'plugins_loaded', 'link_roundups_init' );
  */
 function link_roundups_enqueue_assets() {
 	$plugin_path = plugins_url( basename( __DIR__ ), __DIR__ );
-	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+	$suffix      = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 	wp_register_script(
-		'links-common', $plugin_path . '/js/links-common' . $suffix . '.js',
-		array( 'jquery', 'underscore', 'backbone' ), 0.3, true
+		'links-common',
+		$plugin_path . '/js/links-common' . $suffix . '.js',
+		array( 'jquery', 'underscore', 'backbone' ),
+		0.3,
+		true
 	);
 
 	wp_register_script(
-		'link-roundups', $plugin_path . '/js/lroundups' . $suffix . '.js',
-		array( 'links-common' ), 0.3, true
+		'link-roundups',
+		$plugin_path . '/js/lroundups' . $suffix . '.js',
+		array( 'links-common' ),
+		0.3,
+		true
 	);
 
 	wp_register_style( 'lroundups-admin', $plugin_path . '/css/lroundups-admin' . $suffix . '.css' );
@@ -119,7 +124,8 @@ function link_roundups_enqueue_assets() {
 		wp_enqueue_style( 'lroundups-admin' );
 	}
 
-	if ($screen->base == 'roundup_page_link-roundups-options')
-		wp_enqueue_script('link-roundups');
+	if ( $screen->base == 'roundup_page_link-roundups-options' ) {
+		wp_enqueue_script( 'link-roundups' );
+	}
 }
 add_action( 'admin_enqueue_scripts', 'link_roundups_enqueue_assets' );

--- a/link-roundups.php
+++ b/link-roundups.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/INN/link-roundups
 Description: Use Link Roundups to aggregate links and create roundup posts. Mailchimp API integration and browser bookmark tool. Formerly argo-links from NPR's Project Argo.
 Author: INN Labs
 Author URI: http://labs.inn.org/
-Version: 1.0.0
+Version: 1.0.1
 License: GPLv2
 Text Domain: link-roundups
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "align-text": {
@@ -245,7 +245,7 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -984,7 +984,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-finite": {
@@ -1489,7 +1489,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
     "psl": {
@@ -1537,7 +1537,7 @@
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1623,7 +1623,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "semver": {
@@ -1682,7 +1682,7 @@
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -1698,7 +1698,7 @@
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1707,7 +1707,7 @@
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/INN/link-roundups/"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-less": "~0.12.0",

--- a/templates/options.php
+++ b/templates/options.php
@@ -10,7 +10,7 @@
 			'<p>' . __( 'Read about these settings and using this plugin in <a href="%s">the documentation on GitHub</a>.', 'link-roundups' ) . '</p>',
 			'https://github.com/INN/link-roundups/tree/master/docs'
 		);
-	?>
+		?>
 
 	<a href="#rename"><strong><?php _e( 'Rename Link Roundups', 'link-roundups' ); ?></strong></a> | <a href="#html"><strong><?php _e( 'Custom HTML for Displaying Links', 'link-roundups' ); ?></strong></a>
 	<form method="post" action="options.php">
@@ -25,7 +25,7 @@
 						'<p>' . __( 'Modify the Post Type Name displayed in the WordPress Dashboard Menus and Pages and the Post Type Slug (<a href="%s">learn more</a>) used in the public URL for each Link Roundup post.', 'link-roundups' ) . '</p>',
 						'http://codex.wordpress.org/Glossary#Post_Slug'
 					);
-				?>
+					?>
 				<h4><?php _e( 'Custom Name', 'link-roundups' ); ?></h4>
 				<h5 style="margin-bottom: 0; padding-bottom: 0;"><?php _e( 'Singular (Default: Link Roundup)', 'link-roundups' ); ?></h5>
 				<input type="text" name="lroundups_custom_name_singular" value="<?php echo get_option( 'lroundups_custom_name_singular' ); ?>" />
@@ -36,25 +36,27 @@
 				<h5 style="margin: 0; padding: 0;"><?php _e( 'Current URL Slug for Link Roundups:', 'link-roundups' ); ?></h5>
 				<code style="display:block; margin: 0.33em 0;">
 					<?php echo get_site_url(); ?>/
-					<strong><?php
+					<strong>
+					<?php
 					$custom_slug_setting = get_option( 'lroundups_custom_url' );
 
-					if(!empty($custom_slug_setting)) {
+					if ( ! empty( $custom_slug_setting ) ) {
 						$current_slug = $custom_slug_setting; // apply custom slug
 					} else {
 						$current_slug = 'roundup'; // set plugin default to roundup
 					}
-					echo $current_slug; ?>
+					echo $current_slug;
+					?>
 					</strong>/random-roundup/</code>
 				<?php $custom_slug = get_option( 'lroundups_custom_url' ); ?>
 				<input type="text" name="lroundups_custom_url" value="<?php echo $custom_slug; ?>" />
 				<p><?php _e( 'Must be lowercase with no spaces or special characters -- dashes allowed.', 'link-roundups' ); ?></p>
-			    <?php
-				    printf(
-				    	'<p>' . __( '<strong>IMPORTANT</strong>: Whenever you define a new Custom URL Slug, you <strong>must</strong> also update your <a href="%s"><strong>Permalink Settings</strong></a>.', 'link-roundups' ) . '</p>',
-			    		admin_url( '/options-permalink.php' )
-			    	);
-			    ?>
+				<?php
+					printf(
+						'<p>' . __( '<strong>IMPORTANT</strong>: Whenever you define a new Custom URL Slug, you <strong>must</strong> also update your <a href="%s"><strong>Permalink Settings</strong></a>.', 'link-roundups' ) . '</p>',
+						admin_url( '/options-permalink.php' )
+					);
+					?>
 			</div>
 			<div id="html" class="card">
 				<h3><?php _e( 'Custom HTML for Displaying Links', 'link-roundups' ); ?></h3>
@@ -73,18 +75,19 @@
 				<li><code>#!DESCRIPTION!#</code></li>
 				<li><code>#!SOURCE!#</code></li>
 				<li><code>#!CLASS!#</code><em><small><?php _e( 'Intended for the paragraph wrapper', 'link-roundups' ); ?></small></em></li>
-				<li><code>#!IMAGE!#</code><em><small><?php _e( 'Used to determine the placement of the featured image, if available', 'link-roundups'); ?></small></em></li>
+				<li><code>#!IMAGE!#</code><em><small><?php _e( 'Used to determine the placement of the featured image, if available', 'link-roundups' ); ?></small></em></li>
 				</ul></blockquote>
 
 				<h4><?php _e( 'Link Styling', 'link-roundups' ); ?></h4>
 				<?php
-					echo '<p>' . __('You can add custom classes to your links by using the "class" attribute of the rounduplink shortcode.', 'link-roundups') . '</p>';
-					echo '<p>' . __('For example: <code>[rounduplink class="sponsored" ... ]</code>', 'link-roundups') . '</p>';
-					echo '<p>' . __('With a custom class in place, you can modify the display of certain links via your theme stylesheet.', 'link-roudnups') . '</p>'; ?>
+					echo '<p>' . __( 'You can add custom classes to your links by using the "class" attribute of the rounduplink shortcode.', 'link-roundups' ) . '</p>';
+					echo '<p>' . __( 'For example: <code>[rounduplink class="sponsored" ... ]</code>', 'link-roundups' ) . '</p>';
+					echo '<p>' . __( 'With a custom class in place, you can modify the display of certain links via your theme stylesheet.', 'link-roudnups' ) . '</p>';
+				?>
 			</div>
 
 		<p class="submit">
-			<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'link-roundups' ) ?>" />
+			<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'link-roundups' ); ?>" />
 		</p>
 	</form>
 </div>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,31 +1,41 @@
 <?php
 
-$wp_tests_dir = getenv('WP_TESTS_DIR');
+$wp_tests_dir = getenv( 'WP_TESTS_DIR' );
 require_once $wp_tests_dir . '/includes/functions.php';
 
-$basename = basename(dirname(__DIR__));
+$basename = basename( dirname( __DIR__ ) );
 
 $GLOBALS['wp_tests_options'] = array(
 	'stylesheet' => $basename,
-	'template' => $basename
+	'template'   => $basename,
 );
 
-tests_add_filter('set_current_user', function($arg) {
-	$user = wp_get_current_user();
-	$user->set_role('administrator');
-	return $arg;
-}, 1, 10);
+tests_add_filter(
+	'set_current_user',
+	function( $arg ) {
+		$user = wp_get_current_user();
+		$user->set_role( 'administrator' );
+		return $arg;
+	},
+	1,
+	10
+);
 
-tests_add_filter('filesystem_method', function($arg) {
-	return 'direct';
-}, 1, 10);
+tests_add_filter(
+	'filesystem_method',
+	function( $arg ) {
+		return 'direct';
+	},
+	1,
+	10
+);
 
 function _manually_load_environment() {
-	$plugins_to_active = array (basename(dirname(__DIR__)) . "/link-roundups.php");
+	$plugins_to_active = array( basename( dirname( __DIR__ ) ) . '/link-roundups.php' );
 
-	update_option('active_plugins', $plugins_to_active);
+	update_option( 'active_plugins', $plugins_to_active );
 
 }
-tests_add_filter('muplugins_loaded', '_manually_load_environment');
+tests_add_filter( 'muplugins_loaded', '_manually_load_environment' );
 
 require $wp_tests_dir . '/includes/bootstrap.php';

--- a/tests/inc/lroundups/test-class-link-roundups-widget.php
+++ b/tests/inc/lroundups/test-class-link-roundups-widget.php
@@ -2,20 +2,20 @@
 
 class link_roundups_widget_Tests extends WP_UnitTestCase {
 
-	function test_link_roundups_widget () {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+	function test_link_roundups_widget() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_widget() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_update() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_form() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 }

--- a/tests/inc/lroundups/test-class-link-roundups.php
+++ b/tests/inc/lroundups/test-class-link-roundups.php
@@ -5,11 +5,11 @@ class LinkRoundupsClassTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		// Set up global $post object
-		$this->roundup_post = $this->factory->post->create(array('post_type' => 'roundup'));
+		$this->roundup_post = $this->factory->post->create( array( 'post_type' => 'roundup' ) );
 		global $post;
 		$this->tmp_post = $post;
-		$post = get_post($this->roundup_post);
-		setup_postdata($post);
+		$post           = get_post( $this->roundup_post );
+		setup_postdata( $post );
 	}
 
 	function tearDown() {
@@ -22,17 +22,19 @@ class LinkRoundupsClassTest extends WP_UnitTestCase {
 		// Testing init would be equivalent to test core WordPress functions called within.
 		// There's no need for that kind of testing here.
 		$this->markTestSkipped(
-			'`LinkRoundups::init` returns null and uses only core WordPress functions.');
+			'`LinkRoundups::init` returns null and uses only core WordPress functions.'
+		);
 	}
 
 	function test_lr_get_posts() {
-		$test_query = new WP_Query();
+		$test_query          = new WP_Query();
 		$test_query->is_home = true;
 
-		LinkRoundups::lr_get_posts($test_query);
+		LinkRoundups::lr_get_posts( $test_query );
 
 		$this->assertTrue(
-			in_array('roundup', $test_query->query_vars['post_type']));
+			in_array( 'roundup', $test_query->query_vars['post_type'] )
+		);
 	}
 
 	function test_register_post_type() {
@@ -40,16 +42,17 @@ class LinkRoundupsClassTest extends WP_UnitTestCase {
 
 		LinkRoundups::register_post_type();
 
-		$this->assertTrue(in_array('roundup', array_keys($wp_post_types)));
+		$this->assertTrue( in_array( 'roundup', array_keys( $wp_post_types ) ) );
 	}
 
 	function test_add_custom_post_fields() {
 		$this->markTestSkipped(
-			'`LinkRoundups::add_custom_post_fields` returns null and uses only core WordPress functions.');
+			'`LinkRoundups::add_custom_post_fields` returns null and uses only core WordPress functions.'
+		);
 	}
 
 	function test_display_custom_fields() {
-		$this->expectOutputRegex('/lroundups-display-area/');
+		$this->expectOutputRegex( '/lroundups-display-area/' );
 		LinkRoundups::display_custom_fields();
 	}
 
@@ -57,29 +60,31 @@ class LinkRoundupsClassTest extends WP_UnitTestCase {
 		$test_url = 'http://testurl';
 		$test_des = 'TKTK';
 
-		$_POST['lr_url'] = $test_url;
+		$_POST['lr_url']  = $test_url;
 		$_POST['lr_desc'] = $test_des;
 
-		LinkRoundups::save_custom_fields($this->roundup_post);
+		LinkRoundups::save_custom_fields( $this->roundup_post );
 
-		$post_url = get_post_meta($this->roundup_post, 'lr_url', true);
-		$post_des = get_post_meta($this->roundup_post, 'lr_desc', true);
+		$post_url = get_post_meta( $this->roundup_post, 'lr_url', true );
+		$post_des = get_post_meta( $this->roundup_post, 'lr_desc', true );
 
-		$this->assertEquals($test_url, $post_url);
-		$this->assertEquals($test_des, $post_des);
+		$this->assertEquals( $test_url, $post_url );
+		$this->assertEquals( $test_des, $post_des );
 	}
 
 	function test_add_lroundups_options_page() {
 		$this->markTestSkipped(
-			'`LinkRoundups::add_argo_links_roundup_options_page` returns null and uses only core WordPress functions.');
+			'`LinkRoundups::add_argo_links_roundup_options_page` returns null and uses only core WordPress functions.'
+		);
 	}
 
 	function test_register_mysettings() {
 		$this->markTestSkipped(
-			'`LinkRoundups::register_mysettings` returns null and uses only core WordPress functions.');
+			'`LinkRoundups::register_mysettings` returns null and uses only core WordPress functions.'
+		);
 	}
 
 	function test_build_lroundups_options_page() {
-		$this->markTestSkipped('This test has not been implemented yet.');
+		$this->markTestSkipped( 'This test has not been implemented yet.' );
 	}
 }

--- a/tests/inc/lroundups/test-class-save-to-site-button.php
+++ b/tests/inc/lroundups/test-class-save-to-site-button.php
@@ -3,34 +3,34 @@
 class Save_To_Site_Button_Tests extends WP_UnitTestCase {
 
 	function test_default_imgUrl() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_default_source() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_default_link() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_default_description() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_default_title() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_load() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_shortcut_link() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_init() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 }

--- a/tests/inc/saved-links/test-class-saved-links.php
+++ b/tests/inc/saved-links/test-class-saved-links.php
@@ -3,107 +3,107 @@
 class SavedLinksClassTests extends WP_UnitTestCase {
 
 	function test_init() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_plugin_mce_css() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_styles() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_register_post_type() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_register_rounduplinks_taxonomy() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_custom_post_fields() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_display_custom_fields() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_save_custom_fields() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_media_sideload_image() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_display_custom_columns() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_data_for_custom_columns() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_save_to_site_sub_menu() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_build_lroundups_page() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_saved_links_widget() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_link_roundups_widget() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_the_permalink() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_the_author() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_the_author_posts_link() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_the_content() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_the_excerpt() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_get_html() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_rounduplink_shortcode() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_get_excerpt() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_notice() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_add_notice_query_var() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_admin_notices() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 }

--- a/tests/inc/saved-links/test-saved-links-widget.php
+++ b/tests/inc/saved-links/test-saved-links-widget.php
@@ -2,20 +2,20 @@
 
 class saved_links_widget_Tests extends WP_UnitTestCase {
 
-	function test_saved_links_widget () {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+	function test_saved_links_widget() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_widget() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_update() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_form() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 }

--- a/tests/inc/test-argo-links-compatability.php
+++ b/tests/inc/test-argo-links-compatability.php
@@ -3,7 +3,7 @@
 class ArgoLinksCompatibilityTests extends WP_UnitTestCase {
 
 	function test_redirect_argolinks_requests() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 }

--- a/tests/inc/updates/test-functions.php
+++ b/tests/inc/updates/test-functions.php
@@ -2,12 +2,12 @@
 
 class UpdateFunctionsTests extends WP_UnitTestCase {
 
-	function test_lroundups_update_post_terms () {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+	function test_lroundups_update_post_terms() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test__lroundups_convert_posts() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 }

--- a/tests/inc/updates/test-index.php
+++ b/tests/inc/updates/test-index.php
@@ -3,35 +3,35 @@
 class UpdateIndexTests extends WP_UnitTestCase {
 
 	function test_lroundups_perform_update() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_version() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_need_updates() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_update_admin_notice() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
-	function test_lroundups_register_update_page () {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+	function test_lroundups_register_update_page() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_update_page_view() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_update_page_enqueue_js() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 	function test_lroundups_ajax_update_database() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
 }

--- a/tests/test-link-roundups.php
+++ b/tests/test-link-roundups.php
@@ -6,15 +6,15 @@ class LinkRoundupsFunctionsTests extends WP_UnitTestCase {
 		parent::setUp();
 
 		// Set up global $post object
-		$this->savedlinks_post = $this->factory->post->create(array('post_type' => 'roundup'));
+		$this->savedlinks_post = $this->factory->post->create( array( 'post_type' => 'roundup' ) );
 		global $post;
 		$this->tmp_post = $post;
-		$post = get_post($this->savedlinks_post);
-		setup_postdata($post);
+		$post           = get_post( $this->savedlinks_post );
+		setup_postdata( $post );
 
 		// Mimic the post edit page
-		set_current_screen('post');
-		$screen = get_current_screen();
+		set_current_screen( 'post' );
+		$screen            = get_current_screen();
 		$screen->post_type = 'roundup';
 	}
 
@@ -28,8 +28,8 @@ class LinkRoundupsFunctionsTests extends WP_UnitTestCase {
 		link_roundups_enqueue_assets();
 
 		global $wp_styles, $wp_scripts;
-		$this->assertTrue(!empty($wp_scripts->registered['link-roundups']));
-		$this->assertTrue(!empty($wp_styles->registered['lroundups-admin']));
+		$this->assertTrue( ! empty( $wp_scripts->registered['link-roundups'] ) );
+		$this->assertTrue( ! empty( $wp_styles->registered['lroundups-admin'] ) );
 	}
 
 }


### PR DESCRIPTION
## Changes
This release contains minor bug fixes for the 1.0.1 release.

 - Fixes a syntax error discovered via static analysis that blocked wordpress.org release of version 1.0.0. Pull request [#171](https://github.com/INN/link-roundups/pull/171) for issue [#170](https://github.com/INN/link-roundups/issues/170).
- Fixes a number of [WordPress code standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#rulesets) issues and undefined variables. Pull request [#175](https://github.com/INN/link-roundups/pull/175) for issues [#174](https://github.com/INN/link-roundups/issues/174) and [#169](https://github.com/INN/link-roundups/issues/169).


For https://github.com/INN/link-roundups/issues/172