### PR TITLE
Correct error with the plugin's get_excerpt() function.

### DIFF
--- a/inc/saved-links/class-saved-links.php
+++ b/inc/saved-links/class-saved-links.php
@@ -633,7 +633,7 @@ class SavedLinks {
 			return $content;
 		}
 
-		return self::get_excerpt();
+		return self::get_excerpt( $post );
 	}
 
 	/**


### PR DESCRIPTION
## Changes

This PR passes the expected `$post` to `the_except()` function in `SavedLinks`, to prevent errors. 

## Why

This PR is to fix an issue I noticed when using the Link Roundups plugin with a theme that was not Largo. If you run a search that returns a Saved Link CPT, it throws an error.

For #185

## Testing/Questions

Features that this PR affects:

- Saved Links CPT

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

(I believe so, but please let me know if it's not!) 

Steps to test this PR:

1. On a test site, apply a theme that is not Largo -- a good bet is one of the default themes, like Twenty Twenty.
2. If you don't have any, add at least one "Saved Link"
3. Run a search on the front-end of the site; note that you get an error:

![image](https://user-images.githubusercontent.com/177561/72115419-cf0ae800-32fb-11ea-92e9-93187cb73122.png)

4. Apply the PR.
5. Confirm that the error is now gone, and the search results are displaying as expected:

![image](https://user-images.githubusercontent.com/177561/72115465-fb266900-32fb-11ea-80cd-4bc0897919cb.png)

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [x] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] Contributor would like to be mentioned in the release notes as: Laurel Fulford
- [x] Contributor agrees to the license terms of this repository.
